### PR TITLE
Fix OpenAI structured output JSON schema validation errors

### DIFF
--- a/app/services/ai/content_orchestrator.rb
+++ b/app/services/ai/content_orchestrator.rb
@@ -183,6 +183,8 @@ module Ai
     end
 
     # JSON Schema for orchestration plan - ensures structured output from AI
+    # Note: OpenAI structured output requires additionalProperties: false at all levels
+    # and all properties must be listed in required array
     def orchestration_plan_schema
       {
         type: "object",
@@ -198,13 +200,15 @@ module Ai
                 coordinates: {
                   type: "object",
                   properties: { lat: { type: "number" }, lng: { type: "number" } },
-                  required: %w[lat lng]
+                  required: %w[lat lng],
+                  additionalProperties: false
                 },
                 locations_to_fetch: { type: "integer" },
                 categories: { type: "array", items: { type: "string" } },
                 reasoning: { type: "string" }
               },
-              required: %w[city coordinates categories]
+              required: %w[city country coordinates locations_to_fetch categories reasoning],
+              additionalProperties: false
             }
           },
           tourist_profiles_to_generate: { type: "array", items: { type: "string" } },
@@ -214,10 +218,12 @@ module Ai
               locations: { type: "integer" },
               experiences: { type: "integer" },
               plans: { type: "integer" }
-            }
+            },
+            required: %w[locations experiences plans],
+            additionalProperties: false
           }
         },
-        required: %w[analysis target_cities tourist_profiles_to_generate],
+        required: %w[analysis target_cities tourist_profiles_to_generate estimated_new_content],
         additionalProperties: false
       }
     end

--- a/app/services/ai/country_wide_location_generator.rb
+++ b/app/services/ai/country_wide_location_generator.rb
@@ -507,12 +507,26 @@ module Ai
     end
 
     # JSON Schema for country/cross-region experience generation
+    # Note: OpenAI structured output requires additionalProperties: false at all levels
+    # and all properties must be listed in required array
     def country_experience_schema
+      locale_properties = supported_locales.to_h { |loc| [loc, { type: "string" }] }
+
       {
         type: "object",
         properties: {
-          titles: { type: "object", additionalProperties: { type: "string" } },
-          descriptions: { type: "object", additionalProperties: { type: "string" } },
+          titles: {
+            type: "object",
+            properties: locale_properties,
+            required: supported_locales,
+            additionalProperties: false
+          },
+          descriptions: {
+            type: "object",
+            properties: locale_properties,
+            required: supported_locales,
+            additionalProperties: false
+          },
           location_ids: { type: "array", items: { type: "integer" } }
         },
         required: %w[titles descriptions location_ids],
@@ -743,6 +757,8 @@ module Ai
     end
 
     # JSON Schema for location suggestions
+    # Note: OpenAI structured output requires additionalProperties: false at all levels
+    # and all properties must be listed in required array
     def location_suggestions_schema
       {
         type: "object",
@@ -763,7 +779,8 @@ module Ai
                 why_notable: { type: "string" },
                 estimated_visit_duration: { type: "integer" }
               },
-              required: %w[name lat lng city_name]
+              required: %w[name name_local lat lng city_name location_type category experience_types why_notable estimated_visit_duration],
+              additionalProperties: false
             }
           }
         },
@@ -1293,18 +1310,26 @@ module Ai
     end
 
     # JSON Schema for location enrichment content
+    # Note: OpenAI structured output requires additionalProperties: false at all levels
+    # and all properties must be listed in required array
     def location_enrichment_schema
+      locale_properties = supported_locales.to_h { |loc| [loc, { type: "string" }] }
+
       {
         type: "object",
         properties: {
           descriptions: {
             type: "object",
-            additionalProperties: { type: "string" },
+            properties: locale_properties,
+            required: supported_locales,
+            additionalProperties: false,
             description: "Localized descriptions keyed by locale code"
           },
           historical_context: {
             type: "object",
-            additionalProperties: { type: "string" },
+            properties: locale_properties,
+            required: supported_locales,
+            additionalProperties: false,
             description: "Localized historical context for audio narration"
           }
         },

--- a/app/services/ai/experience_creator.rb
+++ b/app/services/ai/experience_creator.rb
@@ -143,7 +143,11 @@ module Ai
     end
 
     # JSON Schema for experience proposals - ensures structured output from AI
+    # Note: OpenAI structured output requires additionalProperties: false at all levels
+    # and all properties must be listed in required array
     def experiences_proposal_schema
+      locale_properties = supported_locales.to_h { |loc| [loc, { type: "string" }] }
+
       {
         type: "object",
         properties: {
@@ -157,11 +161,22 @@ module Ai
                 category_key: { type: "string" },
                 estimated_duration: { type: "integer" },
                 seasons: { type: "array", items: { type: "string" } },
-                titles: { type: "object", additionalProperties: { type: "string" } },
-                descriptions: { type: "object", additionalProperties: { type: "string" } },
+                titles: {
+                  type: "object",
+                  properties: locale_properties,
+                  required: supported_locales,
+                  additionalProperties: false
+                },
+                descriptions: {
+                  type: "object",
+                  properties: locale_properties,
+                  required: supported_locales,
+                  additionalProperties: false
+                },
                 theme_reasoning: { type: "string" }
               },
-              required: %w[location_ids location_names category_key titles descriptions]
+              required: %w[location_ids location_names category_key estimated_duration seasons titles descriptions theme_reasoning],
+              additionalProperties: false
             }
           }
         },

--- a/app/services/ai/experience_generator.rb
+++ b/app/services/ai/experience_generator.rb
@@ -339,7 +339,11 @@ module Ai
     end
 
     # JSON Schema for location enrichment - ensures structured output from AI
+    # Note: OpenAI structured output requires additionalProperties: false at all levels
+    # and all properties must be listed in required array
     def location_enrichment_schema
+      locale_properties = supported_locales.to_h { |loc| [loc, { type: "string" }] }
+
       {
         type: "object",
         properties: {
@@ -350,12 +354,16 @@ module Ai
           },
           descriptions: {
             type: "object",
-            additionalProperties: { type: "string" },
+            properties: locale_properties,
+            required: supported_locales,
+            additionalProperties: false,
             description: "Localized descriptions keyed by locale code (en, bs, hr, etc.)"
           },
           historical_context: {
             type: "object",
-            additionalProperties: { type: "string" },
+            properties: locale_properties,
+            required: supported_locales,
+            additionalProperties: false,
             description: "Localized historical context for audio narration keyed by locale code"
           }
         },
@@ -681,18 +689,26 @@ module Ai
     end
 
     # JSON Schema for experience generation - ensures structured output from AI
+    # Note: OpenAI structured output requires additionalProperties: false at all levels
+    # and all properties must be listed in required array
     def experience_generation_schema
+      locale_properties = supported_locales.to_h { |loc| [loc, { type: "string" }] }
+
       {
         type: "object",
         properties: {
           titles: {
             type: "object",
-            additionalProperties: { type: "string" },
+            properties: locale_properties,
+            required: supported_locales,
+            additionalProperties: false,
             description: "Localized experience titles keyed by locale code (en, bs, hr, etc.)"
           },
           descriptions: {
             type: "object",
-            additionalProperties: { type: "string" },
+            properties: locale_properties,
+            required: supported_locales,
+            additionalProperties: false,
             description: "Localized experience descriptions keyed by locale code"
           },
           location_ids: {

--- a/app/services/ai/location_enricher.rb
+++ b/app/services/ai/location_enricher.rb
@@ -138,7 +138,11 @@ module Ai
     end
 
     # JSON Schema for location enrichment - ensures structured output from AI
+    # Note: OpenAI structured output requires additionalProperties: false at all levels
+    # and all properties must be listed in required array
     def location_enrichment_schema
+      locale_properties = supported_locales.to_h { |loc| [loc, { type: "string" }] }
+
       {
         type: "object",
         properties: {
@@ -149,12 +153,16 @@ module Ai
           },
           descriptions: {
             type: "object",
-            additionalProperties: { type: "string" },
+            properties: locale_properties,
+            required: supported_locales,
+            additionalProperties: false,
             description: "Localized descriptions keyed by locale code"
           },
           historical_context: {
             type: "object",
-            additionalProperties: { type: "string" },
+            properties: locale_properties,
+            required: supported_locales,
+            additionalProperties: false,
             description: "Localized historical context for audio narration"
           }
         },

--- a/app/services/ai/plan_creator.rb
+++ b/app/services/ai/plan_creator.rb
@@ -139,7 +139,11 @@ module Ai
     end
 
     # JSON Schema for plan proposal - ensures structured output from AI
+    # Note: OpenAI structured output requires additionalProperties: false at all levels
+    # and all properties must be listed in required array
     def plan_proposal_schema
+      locale_properties = supported_locales.to_h { |loc| [loc, { type: "string" }] }
+
       {
         type: "object",
         properties: {
@@ -149,12 +153,16 @@ module Ai
           },
           titles: {
             type: "object",
-            additionalProperties: { type: "string" },
+            properties: locale_properties,
+            required: supported_locales,
+            additionalProperties: false,
             description: "Localized plan titles keyed by locale code (en, bs, hr, etc.)"
           },
           notes: {
             type: "object",
-            additionalProperties: { type: "string" },
+            properties: locale_properties,
+            required: supported_locales,
+            additionalProperties: false,
             description: "Localized travel notes keyed by locale code"
           },
           days: {
@@ -169,7 +177,8 @@ module Ai
                   items: { type: "integer" }
                 }
               },
-              required: %w[day_number theme experience_ids]
+              required: %w[day_number theme experience_ids],
+              additionalProperties: false
             },
             description: "Array of day plans with experience IDs"
           },


### PR DESCRIPTION
OpenAI's structured output API has strict requirements for JSON schemas:
- Every nested object must have `additionalProperties: false`
- All properties in an object must be listed in the `required` array

This fix updates all AI service schemas to comply with these requirements:
- location_enricher.rb: Use explicit locale properties for descriptions/historical_context
- experience_creator.rb: Add additionalProperties: false to nested items, include all properties in required
- content_orchestrator.rb: Add additionalProperties: false at all nested levels (coordinates, target_cities items, estimated_new_content)
- country_wide_location_generator.rb: Fix country_experience_schema, location_suggestions_schema, and location_enrichment_schema
- experience_generator.rb: Fix location_enrichment_schema and experience_generation_schema
- plan_creator.rb: Use explicit locale properties and add additionalProperties: false to day items

The key pattern applied was replacing dynamic additionalProperties with explicit locale properties generated from supported_locales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)