### PR TITLE
Fix missing Kaminari tailwind theme partial error

### DIFF
--- a/app/views/admin/ai/audio_tours/index.html.erb
+++ b/app/views/admin/ai/audio_tours/index.html.erb
@@ -179,7 +179,7 @@
     <% if @locations.total_pages > 1 %>
       <div class="p-4 sm:p-6 border-t bg-gray-50">
         <div class="flex items-center justify-center">
-          <%= paginate @locations, theme: 'tailwind' %>
+          <%= paginate @locations %>
         </div>
       </div>
     <% end %>


### PR DESCRIPTION
Remove the theme: 'tailwind' option from paginate helper since the Kaminari tailwind partials don't exist in the project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)