### PR TITLE
Fix AI proposal timeout error for Banja Luka

### DIFF
--- a/config/initializers/ruby_llm.rb
+++ b/config/initializers/ruby_llm.rb
@@ -15,6 +15,13 @@ RubyLLM.configure do |config|
   # Options: "gpt-4o-mini", "claude-sonnet-4-20250514", "gemini-2.0-flash", etc.
   config.default_model = ENV.fetch("LLM_DEFAULT_MODEL", "gpt-4o-mini")
 
-  # Request timeout in seconds (default: 180s for complex enrichment prompts)
-  config.request_timeout = ENV.fetch("LLM_REQUEST_TIMEOUT", 180).to_i
+  # Request timeout in seconds
+  # Increased to 300s (5 min) for complex AI proposals with structured output
+  # (e.g., multi-language experience descriptions with JSON schema)
+  config.request_timeout = ENV.fetch("LLM_REQUEST_TIMEOUT", 300).to_i
+
+  # Retry configuration for transient network failures (Net::ReadTimeout, etc.)
+  config.max_retries = ENV.fetch("LLM_MAX_RETRIES", 3).to_i
+  config.retry_interval = ENV.fetch("LLM_RETRY_INTERVAL", 1.0).to_f
+  config.retry_backoff_factor = ENV.fetch("LLM_RETRY_BACKOFF_FACTOR", 2.0).to_f
 end


### PR DESCRIPTION
The Ai::ExperienceCreator was experiencing Net::ReadTimeout errors when generating complex proposals for cities like Banja Luka. This was caused by:
- Complex prompts with many locations requiring extended processing
- Multi-language output (en, bs, hr, de) in structured JSON format
- No retry mechanism for transient network failures

Changes:
- Increase request timeout from 180s to 300s (5 min)
- Add retry configuration with exponential backoff (3 retries)
- Make all timeout/retry settings configurable via environment variables