### PR TITLE
Fix plan creation validation error for title

### DIFF
--- a/app/services/ai/plan_creator.rb
+++ b/app/services/ai/plan_creator.rb
@@ -296,7 +296,14 @@ module Ai
     def create_plan_from_proposal(proposal, experiences, profile, city)
       duration_days = proposal[:duration_days] || proposal[:days]&.count || 1
 
+      # Set initial title from proposal or generate default
+      # This is required because Plan validates :title, presence: true
+      initial_title = proposal.dig(:titles, :en) ||
+                      proposal.dig(:titles, "en") ||
+                      generate_default_title(profile, city, "en")
+
       plan = Plan.new(
+        title: initial_title,
         city_name: city || determine_primary_city(proposal, experiences),
         visibility: :public_plan,
         preferences: {


### PR DESCRIPTION
The Plan model validates presence of title, but create_plan_from_proposal was not setting a title before calling save. This caused "Naslov can't be blank" validation error.

Now sets an initial title from the AI proposal's English title, falling back to generate_default_title if not available.