### PR TITLE
Fix audio tour generation and add multi-language support

### DIFF
--- a/app/controllers/admin/ai/audio_tours_controller.rb
+++ b/app/controllers/admin/ai/audio_tours_controller.rb
@@ -49,7 +49,7 @@ module Admin
       # Generiše audio ture za odabrane lokacije
       def generate
         location_ids = params[:location_ids] || []
-        locale = params[:locale] || "bs"
+        locales = params[:locales].presence || ["bs"]
         force = params[:force] == "1"
 
         if location_ids.empty?
@@ -59,10 +59,11 @@ module Admin
 
         locations = Location.where(id: location_ids)
 
-        # Pokreni job za generiranje
+        # Pokreni job za generiranje u batch_multilingual modu
         AudioTourGenerationJob.perform_later(
+          mode: "batch_multilingual",
+          locales: locales,
           location_ids: locations.pluck(:id),
-          locale: locale,
           force: force
         )
 

--- a/app/javascript/controllers/audio_tours_generator_controller.js
+++ b/app/javascript/controllers/audio_tours_generator_controller.js
@@ -9,21 +9,27 @@ export default class extends Controller {
 
   updateCostEstimate() {
     const locationCheckboxes = this.element.querySelectorAll('.location-checkbox')
+    const languageCheckboxes = this.element.querySelectorAll('input[name="locales[]"]:checked')
+    const languageCount = Math.max(languageCheckboxes.length, 1)
+
     let count = 0
-    let chars = 0
+    let baseChars = 0
 
     locationCheckboxes.forEach(cb => {
       if (cb.checked) {
         count++
-        chars += parseInt(cb.dataset.chars || 2000)
+        baseChars += parseInt(cb.dataset.chars || 2000)
       }
     })
 
-    if (count > 0) {
+    // Multiply characters by number of languages selected
+    const totalChars = baseChars * languageCount
+
+    if (count > 0 && languageCount > 0) {
       this.costEstimateTarget.classList.remove('hidden')
-      this.selectedCountTarget.textContent = count
-      this.estCharsTarget.textContent = chars.toLocaleString()
-      const cost = (chars / 1000 * 0.30).toFixed(2)
+      this.selectedCountTarget.textContent = `${count} locations × ${languageCount} languages`
+      this.estCharsTarget.textContent = totalChars.toLocaleString()
+      const cost = (totalChars / 1000 * 0.30).toFixed(2)
       this.estCostTarget.textContent = '$' + cost
       this.generateBtnTarget.disabled = false
     } else {

--- a/app/views/admin/ai/audio_tours/index.html.erb
+++ b/app/views/admin/ai/audio_tours/index.html.erb
@@ -50,27 +50,35 @@
     <!-- Generation Controls - TOP -->
     <div class="p-4 sm:p-6 border-b bg-gray-50">
       <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
-        <div class="flex flex-col sm:flex-row items-stretch sm:items-center gap-3">
-          <div class="flex items-center gap-2">
-            <label for="locale" class="text-sm text-gray-600">Language:</label>
-            <select name="locale" id="locale" class="rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm">
-              <option value="bs">Bosnian</option>
-              <option value="en">English</option>
-              <option value="de">German</option>
-              <option value="hr">Croatian</option>
-              <option value="sr">Serbian</option>
-            </select>
+        <div class="flex flex-col lg:flex-row items-stretch lg:items-center gap-4">
+          <div class="flex flex-col gap-2">
+            <span class="text-sm font-medium text-gray-600">Languages:</span>
+            <div class="flex flex-wrap gap-3">
+              <% AudioTour::SUPPORTED_LOCALES.each do |code, name| %>
+                <label class="flex items-center gap-1.5 text-sm text-gray-700">
+                  <input type="checkbox"
+                         name="locales[]"
+                         value="<%= code %>"
+                         <%= "checked" if AudioTour::DEFAULT_GENERATION_LOCALES.include?(code.to_s) %>
+                         data-action="change->audio-tours-generator#updateCostEstimate"
+                         class="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500">
+                  <%= name %>
+                </label>
+              <% end %>
+            </div>
           </div>
 
-          <label class="flex items-center gap-2 text-sm text-gray-600">
-            <input type="checkbox" name="force" value="1" class="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500">
-            Force regenerate
-          </label>
+          <div class="flex flex-col sm:flex-row items-stretch sm:items-center gap-3">
+            <label class="flex items-center gap-2 text-sm text-gray-600">
+              <input type="checkbox" name="force" value="1" class="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500">
+              Force regenerate
+            </label>
 
-          <div class="text-sm text-gray-500">
-            <button type="button" data-action="audio-tours-generator#selectAll" class="text-indigo-600 hover:text-indigo-800">Select all</button>
-            |
-            <button type="button" data-action="audio-tours-generator#deselectAll" class="text-indigo-600 hover:text-indigo-800">Deselect all</button>
+            <div class="text-sm text-gray-500">
+              <button type="button" data-action="audio-tours-generator#selectAll" class="text-indigo-600 hover:text-indigo-800">Select all</button>
+              |
+              <button type="button" data-action="audio-tours-generator#deselectAll" class="text-indigo-600 hover:text-indigo-800">Deselect all</button>
+            </div>
           </div>
         </div>
 


### PR DESCRIPTION
- Add missing 'mode' parameter to AudioTourGenerationJob call (was causing silent failures)
- Change from single language select to multi-language checkboxes
- Support all 14 languages defined in AudioTour::SUPPORTED_LOCALES
- Default selection: Bosnian, English, German
- Update cost estimation to account for multiple languages