### PR TITLE
Add user interests selection feature

### DIFF
--- a/app/javascript/controllers/plan_wizard_controller.js
+++ b/app/javascript/controllers/plan_wizard_controller.js
@@ -22,6 +22,9 @@ export default class extends Controller {
     "budgetOption",
     "dailyHoursOption",
     "interestTag",
+    "interestsContainer",
+    "loadMoreContainer",
+    "loadMoreButton",
     "toast"
   ]
 
@@ -516,6 +519,26 @@ export default class extends Controller {
       this.formData.interests.splice(index, 1)
       event.currentTarget.classList.add("bg-gray-100", "dark:bg-gray-700", "text-gray-700", "dark:text-gray-300")
       event.currentTarget.classList.remove("bg-primary-500", "text-white")
+    }
+  }
+
+  // Load more interests (show hidden interests)
+  loadMoreInterests(event) {
+    const button = event.currentTarget
+    const initialCount = parseInt(button.dataset.initialCount) || 8
+
+    // Show all hidden interest tags
+    this.interestTagTargets.forEach((tag, index) => {
+      if (index >= initialCount) {
+        tag.classList.remove("hidden")
+        // Add animation
+        tag.classList.add("animate-fade-in")
+      }
+    })
+
+    // Hide the load more button container
+    if (this.hasLoadMoreContainerTarget) {
+      this.loadMoreContainerTarget.classList.add("hidden")
     }
   }
 

--- a/app/jobs/experience_type_sync_job.rb
+++ b/app/jobs/experience_type_sync_job.rb
@@ -1,0 +1,187 @@
+# frozen_string_literal: true
+
+# Background job for syncing experience types from location's suitable_experiences JSONB field
+# This creates missing ExperienceType records and populates the join table
+#
+# Usage:
+#   ExperienceTypeSyncJob.perform_later
+#   ExperienceTypeSyncJob.perform_later(dry_run: true) # Preview changes without saving
+class ExperienceTypeSyncJob < ApplicationJob
+  queue_as :default
+
+  # Retry on transient failures
+  retry_on StandardError, wait: :polynomially_longer, attempts: 3
+
+  def perform(dry_run: false)
+    Rails.logger.info "[ExperienceTypeSyncJob] Starting experience type sync (dry_run: #{dry_run})"
+
+    save_status("in_progress", "Starting experience type sync...")
+
+    results = {
+      started_at: Time.current,
+      total_locations: 0,
+      experience_types_created: 0,
+      associations_created: 0,
+      locations_updated: 0,
+      new_types: [],
+      errors: [],
+      dry_run: dry_run
+    }
+
+    begin
+      # First pass: collect all unique experience type keys from locations
+      all_keys = collect_all_experience_keys(results)
+
+      save_status("in_progress", "Found #{all_keys.size} unique experience types...")
+
+      # Create missing experience types
+      create_missing_experience_types(all_keys, results, dry_run: dry_run)
+
+      save_status("in_progress", "Syncing location associations...")
+
+      # Second pass: sync associations for each location
+      sync_location_associations(results, dry_run: dry_run)
+
+      results[:finished_at] = Time.current
+      results[:status] = "completed"
+
+      message = "Finished: #{results[:experience_types_created]} types created, " \
+                "#{results[:associations_created]} associations, " \
+                "#{results[:locations_updated]} locations updated"
+      message += " (DRY RUN)" if dry_run
+
+      save_status("completed", message, results: results)
+
+      Rails.logger.info "[ExperienceTypeSyncJob] Completed: #{results}"
+      results
+
+    rescue StandardError => e
+      results[:status] = "failed"
+      results[:error] = e.message
+      save_status("failed", e.message, results: results)
+      Rails.logger.error "[ExperienceTypeSyncJob] Failed: #{e.message}"
+      raise
+    end
+  end
+
+  # Returns current status of the job
+  def self.current_status
+    {
+      status: Setting.get("experience_type_sync.status", default: "idle"),
+      message: Setting.get("experience_type_sync.message", default: nil),
+      results: JSON.parse(Setting.get("experience_type_sync.results", default: "{}") || "{}")
+    }
+  rescue JSON::ParserError
+    { status: "idle", message: nil, results: {} }
+  end
+
+  # Clear any existing status
+  def self.clear_status!
+    Setting.set("experience_type_sync.status", "idle")
+    Setting.set("experience_type_sync.message", nil)
+    Setting.set("experience_type_sync.results", "{}")
+  end
+
+  # Force reset a stuck job back to idle
+  def self.force_reset!
+    Setting.set("experience_type_sync.status", "idle")
+    Setting.set("experience_type_sync.message", "Force reset by admin")
+  end
+
+  private
+
+  def collect_all_experience_keys(results)
+    all_keys = Set.new
+
+    Location.where.not(suitable_experiences: nil)
+            .where.not(suitable_experiences: [])
+            .find_each(batch_size: 100) do |location|
+      results[:total_locations] += 1
+
+      experiences = location.read_attribute(:suitable_experiences) || []
+      experiences.each do |key|
+        normalized_key = key.to_s.downcase.strip
+        all_keys.add(normalized_key) if normalized_key.present?
+      end
+
+      # Update status periodically
+      if results[:total_locations] % 100 == 0
+        save_status("in_progress", "Scanned #{results[:total_locations]} locations...")
+      end
+    end
+
+    all_keys.to_a
+  end
+
+  def create_missing_experience_types(keys, results, dry_run:)
+    existing_keys = ExperienceType.pluck(:key).map(&:downcase)
+
+    keys.each do |key|
+      next if existing_keys.include?(key.downcase)
+
+      results[:new_types] << key
+
+      unless dry_run
+        ExperienceType.create!(
+          key: key,
+          name: key.titleize,
+          active: true,
+          position: ExperienceType.maximum(:position).to_i + 1
+        )
+        results[:experience_types_created] += 1
+        Rails.logger.info "[ExperienceTypeSyncJob] Created experience type: #{key}"
+      end
+    end
+  end
+
+  def sync_location_associations(results, dry_run:)
+    processed = 0
+
+    Location.where.not(suitable_experiences: nil)
+            .where.not(suitable_experiences: [])
+            .find_each(batch_size: 50) do |location|
+      processed += 1
+
+      begin
+        experiences = location.read_attribute(:suitable_experiences) || []
+        location_updated = false
+
+        experiences.each do |key|
+          normalized_key = key.to_s.downcase.strip
+          next if normalized_key.blank?
+
+          exp_type = ExperienceType.find_by("LOWER(key) = ?", normalized_key)
+          next unless exp_type
+
+          # Check if association already exists
+          unless location.location_experience_types.exists?(experience_type: exp_type)
+            unless dry_run
+              location.location_experience_types.create!(experience_type: exp_type)
+            end
+            results[:associations_created] += 1
+            location_updated = true
+          end
+        end
+
+        results[:locations_updated] += 1 if location_updated
+
+      rescue StandardError => e
+        results[:errors] << { location_id: location.id, name: location.name, error: e.message }
+        Rails.logger.warn "[ExperienceTypeSyncJob] Error processing #{location.name}: #{e.message}"
+      end
+
+      # Update status periodically
+      if processed % 50 == 0
+        save_status("in_progress", "Processed #{processed} locations... (#{results[:associations_created]} associations created)")
+      end
+    end
+  end
+
+  def save_status(status, message, results: nil)
+    Setting.set("experience_type_sync.status", status)
+    Setting.set("experience_type_sync.message", message)
+    Setting.set("experience_type_sync.results", results.to_json) if results
+  rescue StandardError => e
+    Rails.logger.warn "[ExperienceTypeSyncJob] Could not save status: #{e.message}"
+  end
+end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -187,10 +187,21 @@ class Location < ApplicationRecord
   end
 
   # Helper to add an experience type
+  # Creates the ExperienceType if it doesn't exist (find_or_create)
   def add_experience_type(experience_type_or_key)
-    exp_type = experience_type_or_key.is_a?(ExperienceType) ?
-      experience_type_or_key :
-      ExperienceType.find_by_key(experience_type_or_key)
+    exp_type = if experience_type_or_key.is_a?(ExperienceType)
+      experience_type_or_key
+    else
+      key = experience_type_or_key.to_s.downcase.strip
+      return if key.blank?
+
+      # Find or create the experience type
+      ExperienceType.find_or_create_by!(key: key) do |et|
+        et.name = key.titleize
+        et.active = true
+        et.position = ExperienceType.maximum(:position).to_i + 1
+      end
+    end
 
     return unless exp_type
 

--- a/app/views/admin/ai/_experience_type_sync_status.html.erb
+++ b/app/views/admin/ai/_experience_type_sync_status.html.erb
@@ -1,0 +1,69 @@
+<% case status[:status] %>
+<% when "in_progress" %>
+  <div class="bg-blue-50 border border-blue-200 rounded-lg p-4">
+    <div class="flex items-center justify-between">
+      <div class="flex items-center gap-3">
+        <svg class="h-5 w-5 text-blue-500 animate-spin" fill="none" viewBox="0 0 24 24">
+          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+          <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+        </svg>
+        <div>
+          <span class="text-blue-800 font-medium">Sync in progress</span>
+          <p class="text-blue-600 text-sm"><%= status[:message] %></p>
+        </div>
+      </div>
+      <%= button_to "Force Reset", admin_force_reset_experience_type_sync_admin_ai_path, method: :post, class: "text-xs text-blue-600 hover:text-blue-800 underline", data: { confirm: "Are you sure? This will cancel the current sync." } %>
+    </div>
+  </div>
+
+<% when "completed" %>
+  <div class="bg-green-50 border border-green-200 rounded-lg p-4">
+    <div class="flex items-start gap-3">
+      <svg class="h-5 w-5 text-green-500 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
+      </svg>
+      <div class="flex-1">
+        <span class="text-green-800 font-medium">Sync completed</span>
+        <p class="text-green-600 text-sm"><%= status[:message] %></p>
+        <% if status[:results].present? %>
+          <div class="mt-2 grid grid-cols-2 sm:grid-cols-4 gap-2 text-xs">
+            <div class="bg-green-100 rounded px-2 py-1">
+              <span class="text-green-700">Types created:</span>
+              <span class="font-medium text-green-900"><%= status[:results]["experience_types_created"] || 0 %></span>
+            </div>
+            <div class="bg-green-100 rounded px-2 py-1">
+              <span class="text-green-700">Associations:</span>
+              <span class="font-medium text-green-900"><%= status[:results]["associations_created"] || 0 %></span>
+            </div>
+            <div class="bg-green-100 rounded px-2 py-1">
+              <span class="text-green-700">Locations:</span>
+              <span class="font-medium text-green-900"><%= status[:results]["locations_updated"] || 0 %></span>
+            </div>
+            <% if status[:results]["new_types"].present? && status[:results]["new_types"].any? %>
+              <div class="bg-green-100 rounded px-2 py-1 col-span-2 sm:col-span-4">
+                <span class="text-green-700">New types:</span>
+                <span class="font-medium text-green-900"><%= status[:results]["new_types"].join(", ") %></span>
+              </div>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+
+<% when "failed" %>
+  <div class="bg-red-50 border border-red-200 rounded-lg p-4">
+    <div class="flex items-start gap-3">
+      <svg class="h-5 w-5 text-red-500 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"></path>
+      </svg>
+      <div>
+        <span class="text-red-800 font-medium">Sync failed</span>
+        <p class="text-red-600 text-sm"><%= status[:message] %></p>
+      </div>
+    </div>
+  </div>
+
+<% else %>
+  <div class="text-gray-500 text-sm">No recent sync activity</div>
+<% end %>

--- a/app/views/admin/ai/index.html.erb
+++ b/app/views/admin/ai/index.html.erb
@@ -152,6 +152,67 @@
     </div>
   </div>
 
+  <!-- Sync Experience Types Card -->
+  <div class="bg-white shadow rounded-lg p-6">
+    <div class="max-w-2xl mx-auto">
+      <h2 class="text-lg font-semibold text-gray-900 mb-2 text-center">Sync Experience Types</h2>
+
+      <p class="text-gray-600 mb-4 text-center text-sm">
+        Sync experience types from location data to populate the interests selection in the plan wizard.
+      </p>
+
+      <!-- Sync Status -->
+      <div class="mb-4">
+        <%= render partial: "experience_type_sync_status", locals: { status: @experience_type_sync_status } %>
+      </div>
+
+      <ul class="text-left text-gray-600 mb-6 space-y-2 max-w-md mx-auto text-sm">
+        <li class="flex items-start gap-2">
+          <svg class="h-5 w-5 text-purple-500 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z"></path>
+          </svg>
+          <span>Scans all locations for experience types in suitable_experiences field</span>
+        </li>
+        <li class="flex items-start gap-2">
+          <svg class="h-5 w-5 text-purple-500 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"></path>
+          </svg>
+          <span>Creates missing ExperienceType records automatically</span>
+        </li>
+        <li class="flex items-start gap-2">
+          <svg class="h-5 w-5 text-purple-500 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"></path>
+          </svg>
+          <span>Links locations to experience types via join table</span>
+        </li>
+      </ul>
+
+      <%= form_with url: admin_sync_experience_types_admin_ai_path, method: :post, class: "space-y-4" do |f| %>
+        <div class="flex flex-col items-center gap-4">
+          <div class="flex flex-wrap items-center justify-center gap-4">
+            <label class="flex items-center gap-2 text-sm text-gray-600 cursor-pointer">
+              <input type="checkbox" name="dry_run" value="1" class="rounded border-gray-300 text-gray-600 focus:ring-gray-500">
+              <span>Preview only (no changes)</span>
+            </label>
+          </div>
+
+          <button type="submit"
+                  class="inline-flex items-center gap-2 px-6 py-3 bg-purple-600 text-white font-medium rounded-lg hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-purple-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                  <%= "disabled" if @experience_type_sync_status[:status] == "in_progress" %>>
+            <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"></path>
+            </svg>
+            Sync Experience Types
+          </button>
+        </div>
+      <% end %>
+
+      <p class="text-xs text-gray-400 mt-4 text-center">
+        This populates the "Koji su tvoji interesi?" section in the plan wizard.
+      </p>
+    </div>
+  </div>
+
   <!-- Current State Stats -->
   <div class="bg-white shadow rounded-lg overflow-hidden">
     <h2 class="text-lg font-semibold p-4 sm:p-6 border-b text-gray-900">Current Content State</h2>

--- a/app/views/plans/wizard.html.erb
+++ b/app/views/plans/wizard.html.erb
@@ -323,20 +323,39 @@
           </p>
         </div>
 
-        <!-- Horizontal scrollable tags -->
-        <div class="overflow-x-auto pb-4 -mx-4 sm:-mx-6 px-4 sm:px-6 scrollbar-hide">
-          <div class="flex flex-wrap gap-2 sm:gap-3 justify-center">
-            <% @supported_interests.each do |interest| %>
+        <!-- Interest tags with load more -->
+        <div class="pb-4">
+          <div class="flex flex-wrap gap-2 sm:gap-3 justify-center" data-plan-wizard-target="interestsContainer">
+            <% initial_count = 8 %>
+            <% @supported_interests.each_with_index do |interest, index| %>
               <button type="button"
-                      class="px-3 sm:px-5 py-2 sm:py-3 rounded-full border-2 border-transparent bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-primary-100 dark:hover:bg-primary-900/30 transition-colors cursor-pointer font-medium text-sm sm:text-base"
+                      class="px-3 sm:px-5 py-2 sm:py-3 rounded-full border-2 border-transparent bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-primary-100 dark:hover:bg-primary-900/30 transition-colors cursor-pointer font-medium text-sm sm:text-base <%= index >= initial_count ? 'hidden' : '' %>"
                       data-plan-wizard-target="interestTag"
                       data-tag="<%= interest %>"
-                      data-action="click->plan-wizard#toggleInterest">
+                      data-action="click->plan-wizard#toggleInterest"
+                      data-interest-index="<%= index %>">
                 <%= interest_icon(interest) %>
                 <%= interest_label(interest) %>
               </button>
             <% end %>
           </div>
+
+          <% if @supported_interests.size > initial_count %>
+            <div class="text-center mt-4" data-plan-wizard-target="loadMoreContainer">
+              <button type="button"
+                      class="inline-flex items-center gap-2 px-4 py-2 text-sm text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300 font-medium transition-colors"
+                      data-action="click->plan-wizard#loadMoreInterests"
+                      data-plan-wizard-target="loadMoreButton"
+                      data-initial-count="<%= initial_count %>"
+                      data-total-count="<%= @supported_interests.size %>">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+                </svg>
+                <%= t('common.show_more', default: 'Prikaži više') %>
+                <span class="text-gray-400">(<%= @supported_interests.size - initial_count %>)</span>
+              </button>
+            </div>
+          <% end %>
         </div>
 
         <p class="text-center text-sm text-gray-500 dark:text-gray-400 mt-4">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -122,6 +122,11 @@ Rails.application.routes.draw do
     get "ai/fix_cities_status", to: "ai#fix_cities_status", as: :fix_cities_status_admin_ai
     post "ai/force_reset_city_fix", to: "ai#force_reset_city_fix", as: :force_reset_city_fix_admin_ai
 
+    # Experience Type Sync
+    post "ai/sync_experience_types", to: "ai#sync_experience_types", as: :sync_experience_types_admin_ai
+    get "ai/sync_experience_types_status", to: "ai#sync_experience_types_status", as: :sync_experience_types_status_admin_ai
+    post "ai/force_reset_experience_type_sync", to: "ai#force_reset_experience_type_sync", as: :force_reset_experience_type_sync_admin_ai
+
     # Audio Tours Generator (odvojeno od glavnog AI generatora)
     get "ai/audio_tours", to: "ai/audio_tours#index", as: :ai_audio_tours
     post "ai/audio_tours/generate", to: "ai/audio_tours#generate", as: :generate_admin_ai_audio_tours


### PR DESCRIPTION
- Modify Location#add_experience_type to use find_or_create logic so ExperienceType records are automatically created when adding new types to locations

- Add ExperienceTypeSyncJob for retroactive sync of experience types from location's suitable_experiences JSONB field to the join table

- Add admin dashboard UI section for triggering the sync job with dry-run preview option

- Update plan wizard interests section with "Load More" pagination (shows first 8 interests initially, then reveals the rest)

This fixes the empty "Koji su tvoji interesi?" section by ensuring experience types are properly created and synced.