### PR TITLE
Fix Infinity error in ContentOrchestrator

### DIFF
--- a/app/services/ai/country_wide_location_generator.rb
+++ b/app/services/ai/country_wide_location_generator.rb
@@ -396,6 +396,10 @@ module Ai
     def select_cross_region_locations(locations_by_region, theme)
       selected = []
       regions = locations_by_region.keys.shuffle
+
+      # Guard against empty regions to avoid division by zero (Infinity)
+      return selected if regions.empty?
+
       max_per_region = (theme[:max_locations].to_f / regions.count).ceil
 
       regions.each do |region|


### PR DESCRIPTION
Guard against empty categories/regions arrays before performing division to prevent Float::INFINITY values that caused "Infinity" errors when processing cities like Banja Luka.

- Use .presence to ensure default_categories fallback works for empty arrays
- Add early return guards for empty categories in fetch_locations
- Add early return guard for empty regions in select_cross_region_locations
- Extract results_per_category calculation to avoid repeated computation