### PR TITLE
Fix Geoapify API category validation error

### DIFF
--- a/app/services/geoapify_service.rb
+++ b/app/services/geoapify_service.rb
@@ -33,7 +33,6 @@ class GeoapifyService
     catering.pub
     catering.biergarten
     catering.taproom
-    catering.winery
     catering.ice_cream
     commercial.marketplace
     commercial.shopping_mall
@@ -245,7 +244,6 @@ class GeoapifyService
     "catering.pub" => "pub",
     "catering.biergarten" => "beer_garden",
     "catering.taproom" => "brewery",
-    "catering.winery" => "winery",
     "catering.food_court" => "food_court",
     "catering.ice_cream" => "ice_cream_shop",
 

--- a/config/initializers/geoapify.rb
+++ b/config/initializers/geoapify.rb
@@ -91,7 +91,6 @@ Rails.application.config.geoapify.tourism_categories = %w[
   catering.pub
   catering.biergarten
   catering.taproom
-  catering.winery
   catering.food_court
   catering.ice_cream
 


### PR DESCRIPTION
The catering.winery category does not exist in Geoapify's API, causing 400 errors when querying for heritage.unesco locations. The valid category production.winery was already present in both files.