### PR TITLE
Display multiple cities for nationwide plans

### DIFF
--- a/app/models/experience.rb
+++ b/app/models/experience.rb
@@ -141,6 +141,11 @@ class Experience < ApplicationRecord
     locations.first&.city
   end
 
+  # Get all unique cities from all locations (for multi-city display)
+  def cities
+    locations.map(&:city).compact.uniq
+  end
+
   # Check if experience has any contact information
   def has_contact_info?
     contact_name.present? || contact_email.present? || contact_phone.present? || contact_website.present?

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -233,6 +233,11 @@ class Plan < ApplicationRecord
     user_id.present?
   end
 
+  # Get all unique cities from all experiences' locations (for multi-city display)
+  def cities
+    experiences.includes(:locations).flat_map(&:cities).uniq
+  end
+
   # Duration in days for user plans (from actual experiences, then preferences)
   # Prioritizes actual experience data over preferences
   def calculated_duration_days
@@ -427,7 +432,8 @@ class Plan < ApplicationRecord
                 location_type: loc.location_type,
                 budget: loc.budget,
                 lat: loc.lat,
-                lng: loc.lng
+                lng: loc.lng,
+                city: loc.city
               }
             end
           }

--- a/app/views/new_design/explore/_experience_card.html.erb
+++ b/app/views/new_design/explore/_experience_card.html.erb
@@ -37,12 +37,15 @@
       <%= experience.title %>
     </h3>
 
-    <% if experience.city.present? %>
+    <% cities = experience.cities %>
+    <% if cities.any? %>
       <p class="mt-1 text-sm text-gray-500 dark:text-gray-400 flex items-center">
-        <svg class="w-3.5 h-3.5 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <svg class="w-3.5 h-3.5 mr-1 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"></path>
         </svg>
-        <%= experience.city %>
+        <span class="truncate">
+          <%= cities.first(2).join(", ") %><% if cities.size > 2 %> <span class="text-gray-400 dark:text-gray-500">+<%= cities.size - 2 %></span><% end %>
+        </span>
       </p>
     <% end %>
 

--- a/app/views/new_design/explore/_plan_card.html.erb
+++ b/app/views/new_design/explore/_plan_card.html.erb
@@ -16,12 +16,15 @@
       <%= plan.display_title.presence || t('profile.my_plans.untitled', default: 'Plan bez naziva') %>
     </h3>
 
-    <% if plan.city_name.present? %>
+    <% cities = plan.cities.presence || [plan.city_name].compact %>
+    <% if cities.any? %>
       <p class="mt-1 text-sm text-gray-500 dark:text-gray-400 flex items-center">
-        <svg class="w-3.5 h-3.5 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <svg class="w-3.5 h-3.5 mr-1 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"></path>
         </svg>
-        <%= plan.city_name %>
+        <span class="truncate">
+          <%= cities.first(2).join(", ") %><% if cities.size > 2 %> <span class="text-gray-400 dark:text-gray-500">+<%= cities.size - 2 %></span><% end %>
+        </span>
       </p>
     <% end %>
 

--- a/app/views/travel_profiles/_my_plan_card.html.erb
+++ b/app/views/travel_profiles/_my_plan_card.html.erb
@@ -18,13 +18,18 @@
         <%= plan.display_title.presence || t('profile.my_plans.untitled', default: 'Plan bez naziva') %>
       </h3>
 
-      <%# City name %>
+      <%# City name(s) %>
+      <% cities = plan.cities.presence || [plan.city_name].compact %>
       <p class="text-xs sm:text-sm text-gray-600 dark:text-gray-300 mt-0.5 truncate">
         <svg class="w-3 h-3 sm:w-3.5 sm:h-3.5 inline mr-1 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"></path>
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"></path>
         </svg>
-        <%= plan.city_name.presence || t('profile.my_plans.unknown_city', default: 'Nepoznat grad') %>
+        <% if cities.any? %>
+          <%= cities.first(2).join(", ") %><% if cities.size > 2 %> <span class="text-gray-400 dark:text-gray-500">+<%= cities.size - 2 %></span><% end %>
+        <% else %>
+          <%= t('profile.my_plans.unknown_city', default: 'Nepoznat grad') %>
+        <% end %>
       </p>
 
       <%# Meta info row - wrap on mobile %>


### PR DESCRIPTION
- Add cities() method to Experience model to get all unique cities from locations
- Add cities() method to Plan model to derive cities from experiences' locations
- Update experience card to show up to 2 cities with "+N" indicator for more
- Update plan cards (explore, profile) to display multiple cities
- Update my_plans_controller.js to extract and display cities from localStorage
- Include city in plan export format for client-side city extraction