### PR TITLE
Fix location view layout on mobile

### DIFF
--- a/app/views/locations/show.html.erb
+++ b/app/views/locations/show.html.erb
@@ -46,11 +46,11 @@
 
       <div class="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-8">
         <%# Left side - Title and basic info %>
-        <div class="flex-1">
+        <div class="flex-1 min-w-0">
           <span class="inline-block px-3 py-1 bg-blue-100 dark:bg-blue-900/30 rounded-full text-xs font-semibold text-blue-600 dark:text-blue-400 mb-4">
             <%= t("locations.types.#{@location.location_type}") %>
           </span>
-          <h1 class="text-4xl sm:text-5xl font-extrabold tracking-tight text-gray-900 dark:text-white">
+          <h1 class="text-4xl sm:text-5xl font-extrabold tracking-tight text-gray-900 dark:text-white break-words">
             <%= @location.translate(:name, I18n.locale) %>
           </h1>
           <% if @location.city %>


### PR DESCRIPTION
Add min-w-0 to the left content flex container to allow it to shrink below its content's intrinsic minimum width on mobile screens. Also add break-words to the title h1 to handle very long location names.