### PR TITLE
Fix mobile scrolling and responsive width issues

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -45,7 +45,7 @@
     <%= javascript_importmap_tags %>
   </head>
 
-  <body class="h-full bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100 transition-colors duration-300">
+  <body class="h-full bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100 transition-colors duration-300 overflow-x-hidden">
     <%= render "shared/pwa_install_banner" %>
     <%= render "shared/cookie_consent" %>
     <%= render "shared/offline_banner" %>

--- a/app/views/new_design/explore.html.erb
+++ b/app/views/new_design/explore.html.erb
@@ -4,7 +4,7 @@
   - Omogućava pretragu lokacija, iskustava i planova
 %>
 
-<div class="bg-white dark:bg-gray-900 min-h-screen">
+<div class="bg-white dark:bg-gray-900 min-h-screen overflow-x-hidden">
   <%= render "new_design/header" %>
 
   <main data-controller="explore" data-explore-search-url-value="<%= explore_path %>">

--- a/app/views/new_design/home.html.erb
+++ b/app/views/new_design/home.html.erb
@@ -18,7 +18,7 @@
   cta_background_image = shuffled_images[6] || shuffled_images.second || shuffled_images.first
 %>
 
-<div class="bg-white dark:bg-gray-900 min-h-screen">
+<div class="bg-white dark:bg-gray-900 min-h-screen overflow-x-hidden">
   <%= render "new_design/header" %>
 
   <main>


### PR DESCRIPTION
Added overflow-x-hidden to:
- Body element in application layout (global fix)
- Home page wrapper div
- Explore page wrapper div

This prevents decorative blur gradient elements with fixed widths (w-[50rem]) from causing horizontal scrolling on mobile devices.