### PR TITLE
Fix location field in Experience and Plan

### DIFF
--- a/app/views/locations/show.html.erb
+++ b/app/views/locations/show.html.erb
@@ -55,10 +55,10 @@
           </h1>
           <% if @location.city %>
             <p class="text-gray-600 dark:text-gray-400 mt-3 flex items-center text-lg">
-              <svg class="w-5 h-5 mr-2 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg class="w-5 h-5 mr-2 text-gray-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"></path>
               </svg>
-              <%= @location.city %>
+              <span class="break-words"><%= @location.city %></span>
             </p>
           <% end %>
 
@@ -458,7 +458,7 @@
                 <div class="flex items-center justify-between mb-2">
                   <span class="text-sm text-gray-500 dark:text-gray-400"><%= t("locations.show.coordinates", default: "Koordinate") %></span>
                 </div>
-                <div class="font-mono text-sm text-gray-900 dark:text-white">
+                <div class="font-mono text-sm text-gray-900 dark:text-white break-all">
                   <%= number_with_precision(@location.lat, precision: 6) %>, <%= number_with_precision(@location.lng, precision: 6) %>
                 </div>
               </div>
@@ -495,23 +495,23 @@
             <div class="space-y-3">
               <% if @location.phone.present? %>
                 <a href="tel:<%= @location.phone %>" class="flex items-center text-gray-700 dark:text-gray-300 hover:text-emerald-600 dark:hover:text-emerald-400">
-                  <svg class="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <svg class="w-5 h-5 mr-3 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"></path>
                   </svg>
-                  <%= @location.phone %>
+                  <span class="break-all"><%= @location.phone %></span>
                 </a>
               <% end %>
               <% if @location.email.present? %>
-                <a href="mailto:<%= @location.email %>" class="flex items-center text-gray-700 dark:text-gray-300 hover:text-emerald-600 dark:hover:text-emerald-400">
-                  <svg class="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <a href="mailto:<%= @location.email %>" class="flex items-center text-gray-700 dark:text-gray-300 hover:text-emerald-600 dark:hover:text-emerald-400 min-w-0">
+                  <svg class="w-5 h-5 mr-3 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"></path>
                   </svg>
-                  <%= @location.email %>
+                  <span class="truncate"><%= @location.email %></span>
                 </a>
               <% end %>
               <% if @location.website.present? %>
                 <a href="<%= @location.website %>" target="_blank" class="flex items-center text-gray-700 dark:text-gray-300 hover:text-emerald-600 dark:hover:text-emerald-400">
-                  <svg class="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <svg class="w-5 h-5 mr-3 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9"></path>
                   </svg>
                   <%= t("locations.show.website", default: "Web stranica") %>


### PR DESCRIPTION
- Add flex-shrink-0 to city icon SVG to prevent icon shrinking
- Wrap city text in span with break-words class
- Add break-all to coordinates display for long coordinate strings
- Add flex-shrink-0 to contact info SVG icons (phone, email, website)
- Wrap phone text in span with break-all class
- Add min-w-0 to email link and wrap email in truncate span