### PR TITLE
Fix broken location display

### DIFF
--- a/app/views/experiences/show.html.erb
+++ b/app/views/experiences/show.html.erb
@@ -20,7 +20,7 @@
           <path d="M.5 200V.5H200" fill="none" />
         </pattern>
       </defs>
-      <svg x="50%" y="-1" class="overflow-visible fill-gray-50 dark:fill-gray-800">
+      <svg x="50%" y="-1" class="fill-gray-50 dark:fill-gray-800">
         <path d="M-200 0h201v201h-201Z M600 0h201v201h-201Z M-400 600h201v201h-201Z M200 800h201v201h-201Z" stroke-width="0" />
       </svg>
       <rect width="100%" height="100%" fill="url(#experience-hero-pattern)" stroke-width="0" />
@@ -28,7 +28,7 @@
 
     <%# Blur gradient accent %>
     <div aria-hidden="true" class="absolute top-0 right-0 left-1/2 -z-10 -ml-24 transform-gpu overflow-hidden blur-3xl lg:ml-24 xl:ml-48">
-      <div style="clip-path: polygon(63.1% 29.5%, 100% 17.1%, 76.6% 3%, 48.4% 0%, 44.6% 4.7%, 54.5% 25.3%, 59.8% 49%, 55.2% 57.8%, 44.4% 57.2%, 27.8% 47.9%, 35.1% 81.5%, 0% 97.7%, 39.2% 100%, 35.2% 81.4%, 97.2% 52.8%, 63.1% 29.5%); aspect-ratio: 801/1036;" class="w-[50rem] bg-gradient-to-tr from-purple-400/30 to-indigo-400/30 dark:from-purple-600/20 dark:to-indigo-500/20 opacity-70"></div>
+      <div style="clip-path: polygon(63.1% 29.5%, 100% 17.1%, 76.6% 3%, 48.4% 0%, 44.6% 4.7%, 54.5% 25.3%, 59.8% 49%, 55.2% 57.8%, 44.4% 57.2%, 27.8% 47.9%, 35.1% 81.5%, 0% 97.7%, 39.2% 100%, 35.2% 81.4%, 97.2% 52.8%, 63.1% 29.5%); aspect-ratio: 801/1036;" class="w-[50rem] max-w-[100vw] bg-gradient-to-tr from-purple-400/30 to-indigo-400/30 dark:from-purple-600/20 dark:to-indigo-500/20 opacity-70"></div>
     </div>
 
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-8 pb-12">

--- a/app/views/locations/show.html.erb
+++ b/app/views/locations/show.html.erb
@@ -24,7 +24,7 @@
           <path d="M.5 200V.5H200" fill="none" />
         </pattern>
       </defs>
-      <svg x="50%" y="-1" class="overflow-visible fill-gray-50 dark:fill-gray-800">
+      <svg x="50%" y="-1" class="fill-gray-50 dark:fill-gray-800">
         <path d="M-200 0h201v201h-201Z M600 0h201v201h-201Z M-400 600h201v201h-201Z M200 800h201v201h-201Z" stroke-width="0" />
       </svg>
       <rect width="100%" height="100%" fill="url(#location-hero-pattern)" stroke-width="0" />
@@ -32,7 +32,7 @@
 
     <%# Blur gradient accent %>
     <div aria-hidden="true" class="absolute top-0 right-0 left-1/2 -z-10 -ml-24 transform-gpu overflow-hidden blur-3xl lg:ml-24 xl:ml-48">
-      <div style="clip-path: polygon(63.1% 29.5%, 100% 17.1%, 76.6% 3%, 48.4% 0%, 44.6% 4.7%, 54.5% 25.3%, 59.8% 49%, 55.2% 57.8%, 44.4% 57.2%, 27.8% 47.9%, 35.1% 81.5%, 0% 97.7%, 39.2% 100%, 35.2% 81.4%, 97.2% 52.8%, 63.1% 29.5%); aspect-ratio: 801/1036;" class="w-[50rem] bg-gradient-to-tr from-emerald-400/30 to-blue-400/30 dark:from-emerald-600/20 dark:to-blue-500/20 opacity-70"></div>
+      <div style="clip-path: polygon(63.1% 29.5%, 100% 17.1%, 76.6% 3%, 48.4% 0%, 44.6% 4.7%, 54.5% 25.3%, 59.8% 49%, 55.2% 57.8%, 44.4% 57.2%, 27.8% 47.9%, 35.1% 81.5%, 0% 97.7%, 39.2% 100%, 35.2% 81.4%, 97.2% 52.8%, 63.1% 29.5%); aspect-ratio: 801/1036;" class="w-[50rem] max-w-[100vw] bg-gradient-to-tr from-emerald-400/30 to-blue-400/30 dark:from-emerald-600/20 dark:to-blue-500/20 opacity-70"></div>
     </div>
 
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-8 pb-12">


### PR DESCRIPTION
- Remove overflow-visible class from hero SVG patterns
- Add max-w-[100vw] to blur gradient elements to prevent overflow