### PR TITLE
Fix experience show page on mobile

### DIFF
--- a/app/views/experiences/show.html.erb
+++ b/app/views/experiences/show.html.erb
@@ -20,7 +20,7 @@
           <path d="M.5 200V.5H200" fill="none" />
         </pattern>
       </defs>
-      <svg x="50%" y="-1" class="fill-gray-50 dark:fill-gray-800">
+      <svg x="50%" y="-1" class="overflow-visible fill-gray-50 dark:fill-gray-800">
         <path d="M-200 0h201v201h-201Z M600 0h201v201h-201Z M-400 600h201v201h-201Z M200 800h201v201h-201Z" stroke-width="0" />
       </svg>
       <rect width="100%" height="100%" fill="url(#experience-hero-pattern)" stroke-width="0" />
@@ -28,7 +28,7 @@
 
     <%# Blur gradient accent %>
     <div aria-hidden="true" class="absolute top-0 right-0 left-1/2 -z-10 -ml-24 transform-gpu overflow-hidden blur-3xl lg:ml-24 xl:ml-48">
-      <div style="clip-path: polygon(63.1% 29.5%, 100% 17.1%, 76.6% 3%, 48.4% 0%, 44.6% 4.7%, 54.5% 25.3%, 59.8% 49%, 55.2% 57.8%, 44.4% 57.2%, 27.8% 47.9%, 35.1% 81.5%, 0% 97.7%, 39.2% 100%, 35.2% 81.4%, 97.2% 52.8%, 63.1% 29.5%); aspect-ratio: 801/1036;" class="w-[50rem] max-w-[100vw] bg-gradient-to-tr from-purple-400/30 to-indigo-400/30 dark:from-purple-600/20 dark:to-indigo-500/20 opacity-70"></div>
+      <div style="clip-path: polygon(63.1% 29.5%, 100% 17.1%, 76.6% 3%, 48.4% 0%, 44.6% 4.7%, 54.5% 25.3%, 59.8% 49%, 55.2% 57.8%, 44.4% 57.2%, 27.8% 47.9%, 35.1% 81.5%, 0% 97.7%, 39.2% 100%, 35.2% 81.4%, 97.2% 52.8%, 63.1% 29.5%); aspect-ratio: 801/1036;" class="w-[50rem] bg-gradient-to-tr from-purple-400/30 to-indigo-400/30 dark:from-purple-600/20 dark:to-indigo-500/20 opacity-70"></div>
     </div>
 
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-8 pb-12">


### PR DESCRIPTION
The previous fix (#40) broke the experience show on mobile. Reverting to match the working plan show view structure by:
- Adding overflow-visible back to hero SVG pattern
- Removing max-w-[100vw] from blur gradient element