### PR TITLE
Analyze experience show page rendering

### DIFF
--- a/app/views/experiences/show.html.erb
+++ b/app/views/experiences/show.html.erb
@@ -232,9 +232,9 @@
       <%# Main Content %>
       <div class="lg:col-span-2 space-y-8">
         <%# Description %>
-        <div class="bg-white dark:bg-gray-800 rounded-2xl p-6 shadow-lg">
+        <div class="bg-white dark:bg-gray-800 rounded-2xl p-4 sm:p-6 shadow-lg">
           <h2 class="text-xl font-bold text-gray-900 dark:text-white mb-4"><%= t("experiences.show.about", default: "O iskustvu") %></h2>
-          <p class="text-gray-700 dark:text-gray-300 leading-relaxed break-words">
+          <p class="text-gray-700 dark:text-gray-300 leading-relaxed break-words whitespace-pre-line [overflow-wrap:anywhere]">
             <%= @experience.translate(:description, I18n.locale) %>
           </p>
         </div>


### PR DESCRIPTION
- Add responsive padding (p-4 sm:p-6) for better mobile spacing
- Add whitespace-pre-line to preserve newlines in descriptions
- Add overflow-wrap:anywhere for better handling of long URLs