### PR TITLE
Fix Reviews section mobile display issues

### DIFF
--- a/app/views/experiences/show.html.erb
+++ b/app/views/experiences/show.html.erb
@@ -314,7 +314,7 @@
         <% end %>
 
         <%# Reviews Section %>
-        <div class="bg-white dark:bg-gray-800 rounded-2xl p-6 shadow-lg">
+        <div class="bg-white dark:bg-gray-800 rounded-2xl p-4 sm:p-6 shadow-lg">
           <%= render "reviews/reviews_section", reviewable: @experience %>
         </div>
       </div>

--- a/app/views/locations/show.html.erb
+++ b/app/views/locations/show.html.erb
@@ -394,7 +394,7 @@
         </div>
 
         <%# Reviews Section %>
-        <div class="bg-white dark:bg-gray-800 rounded-2xl p-6 shadow-lg">
+        <div class="bg-white dark:bg-gray-800 rounded-2xl p-4 sm:p-6 shadow-lg">
           <%= render "reviews/reviews_section", reviewable: @location %>
         </div>
       </div>

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -353,7 +353,7 @@
         <% end %>
 
         <%# Reviews Section %>
-        <div class="bg-white dark:bg-gray-800 rounded-2xl p-6 shadow-lg">
+        <div class="bg-white dark:bg-gray-800 rounded-2xl p-4 sm:p-6 shadow-lg">
           <%= render "reviews/reviews_section", reviewable: @plan %>
         </div>
       </div>

--- a/app/views/reviews/_form.html.erb
+++ b/app/views/reviews/_form.html.erb
@@ -1,8 +1,8 @@
 <%# Review form component %>
 <%# Usage: render "reviews/form", reviewable: @location, review: @review %>
 
-<div id="review-form" class="bg-white dark:bg-gray-800 rounded-2xl p-6 shadow-lg">
-  <h3 class="text-xl font-bold text-gray-900 dark:text-white mb-4">
+<div id="review-form" class="bg-white dark:bg-gray-800 rounded-2xl p-4 sm:p-6 shadow-lg">
+  <h3 class="text-lg sm:text-xl font-bold text-gray-900 dark:text-white mb-4">
     <%= t("reviews.form.title", default: "Ostavi recenziju") %>
   </h3>
 
@@ -27,7 +27,7 @@
                   data-star-rating-value-param="<%= i + 1 %>"
                   class="star-btn p-1 focus:outline-none transition-colors"
                   data-star-rating-target="star">
-            <svg class="w-8 h-8 text-gray-300 dark:text-gray-600 hover:text-amber-400 transition-colors" fill="currentColor" viewBox="0 0 20 20">
+            <svg class="w-6 h-6 sm:w-8 sm:h-8 text-gray-300 dark:text-gray-600 hover:text-amber-400 transition-colors" fill="currentColor" viewBox="0 0 20 20">
               <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"></path>
             </svg>
           </button>

--- a/app/views/reviews/_review_card.html.erb
+++ b/app/views/reviews/_review_card.html.erb
@@ -1,5 +1,5 @@
-<div class="bg-gray-50 dark:bg-gray-700 rounded-xl p-5">
-  <div class="flex items-start justify-between mb-3">
+<div class="bg-gray-50 dark:bg-gray-700 rounded-xl p-4 sm:p-5">
+  <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-2 sm:gap-0 mb-3">
     <div class="flex items-center space-x-3">
       <div class="w-10 h-10 bg-gradient-to-br from-emerald-400 to-teal-500 rounded-full flex items-center justify-center text-white font-bold">
         <%= review.author_name.present? ? review.author_name[0].upcase : "?" %>

--- a/app/views/reviews/_reviews_section.html.erb
+++ b/app/views/reviews/_reviews_section.html.erb
@@ -11,10 +11,10 @@
 
 <div id="reviews-section" class="space-y-6">
   <%# Reviews Header %>
-  <div class="flex items-center justify-between">
-    <h3 class="text-xl font-bold text-gray-900 dark:text-white">
+  <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-2">
+    <h3 class="text-lg sm:text-xl font-bold text-gray-900 dark:text-white">
       <%= t("reviews.title", default: "Recenzije") %>
-      <span class="text-gray-500 dark:text-gray-400 font-normal text-base ml-2">(<%= total_reviews %>)</span>
+      <span class="text-gray-500 dark:text-gray-400 font-normal text-sm sm:text-base ml-1 sm:ml-2">(<%= total_reviews %>)</span>
     </h3>
     <% if reviewable.has_reviews? %>
       <div class="flex items-center space-x-2">


### PR DESCRIPTION
- Add responsive padding (p-4 sm:p-6) to Reviews container in experience, plan, and location show pages
- Make reviews header stack vertically on mobile with flex-col sm:flex-row
- Add responsive text sizing for header (text-lg sm:text-xl)
- Update review card padding (p-4 sm:p-5) and make header responsive
- Update review form padding and star rating sizes (w-6 h-6 sm:w-8 sm:h-8)

Follows the same responsive pattern established in previous mobile fixes.