### PR TITLE
Fix missing translation_for method in Experience

### DIFF
--- a/app/models/concerns/translatable.rb
+++ b/app/models/concerns/translatable.rb
@@ -75,8 +75,9 @@ module Translatable
     send(field) if respond_to?(field)
   end
 
-  # Alias for translate
+  # Aliases for translate
   alias_method :t, :translate
+  alias_method :translation_for, :translate
 
   # Set translation for a field
   #


### PR DESCRIPTION
The ExperienceAnalyzer and other services call translation_for() on Experience models, but this method didn't exist. Add it as an alias to the existing translate() method.