### PR TITLE
Fix API response schema validation error

### DIFF
--- a/app/jobs/rebuild_experiences_job.rb
+++ b/app/jobs/rebuild_experiences_job.rb
@@ -411,7 +411,7 @@ class RebuildExperiencesJob < ApplicationJob
         },
         estimated_duration: { type: "integer" }
       },
-      required: %w[titles descriptions],
+      required: %w[titles descriptions estimated_duration],
       additionalProperties: false
     }
   end


### PR DESCRIPTION
OpenAI's structured output API requires all properties defined in the schema to be included in the required array. Added 'estimated_duration' to the required array in regeneration_schema to fix the validation error.