### PR TITLE
Filter Rebuild Plans to AI-generated jobs only

### DIFF
--- a/app/jobs/rebuild_plans_job.rb
+++ b/app/jobs/rebuild_plans_job.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
-# Background job for analyzing and rebuilding plans that have quality issues
-# or are too similar to other plans
+# Background job for analyzing and rebuilding AI-generated plans that have quality issues
+# or are too similar to other plans. Only processes plans where user_id is nil (AI-generated).
+# User-owned plans are never modified by this job.
 #
 # Usage:
 #   RebuildPlansJob.perform_later                          # Analyze and rebuild

--- a/app/services/ai/plan_analyzer.rb
+++ b/app/services/ai/plan_analyzer.rb
@@ -74,12 +74,13 @@ module Ai
       }
     end
 
-    # Analyze all plans and find quality issues
+    # Analyze all AI-generated plans and find quality issues
     # @return [Array<Hash>] Array of analysis results
     def analyze_all
       results = []
 
-      Plan.includes(:plan_experiences, :experiences, :translations).find_each do |plan|
+      # Only analyze AI-generated plans (user_id is nil)
+      Plan.where(user_id: nil).includes(:plan_experiences, :experiences, :translations).find_each do |plan|
         result = analyze(plan)
         results << result unless result[:skipped]
       end
@@ -111,12 +112,13 @@ module Ai
       similar_groups.sort_by { |g| -g[:similarity][:overall] }
     end
 
-    # Get a comprehensive report of all quality issues
+    # Get a comprehensive report of all quality issues for AI-generated plans
     # @return [Hash] Report with statistics and issues by type
     def generate_report
       all_results = []
 
-      Plan.includes(:plan_experiences, :experiences, :translations).find_each do |plan|
+      # Only analyze AI-generated plans (user_id is nil)
+      Plan.where(user_id: nil).includes(:plan_experiences, :experiences, :translations).find_each do |plan|
         result = analyze(plan)
         all_results << result unless result[:skipped]
       end


### PR DESCRIPTION
Update PlanAnalyzer to query only plans where user_id is nil (AI-generated plans) instead of loading all plans and filtering in memory. This improves efficiency and ensures user-owned plans are never processed by the rebuild job.