### PR TITLE
Add experience replacement to plan rebuild and Admin UI improvements

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -94,6 +94,9 @@ group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
   gem "selenium-webdriver"
+
+  # Pin minitest to 5.x - version 6.0 has breaking changes incompatible with Rails 8.1
+  gem "minitest", "~> 5.25"
 end
 
 gem "tailwindcss-rails", "~> 4.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -232,8 +232,7 @@ GEM
       logger
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
-    minitest (6.0.1)
-      prism (~> 1.5)
+    minitest (5.27.0)
     msgpack (1.8.0)
     multipart-post (2.4.1)
     net-http (0.9.1)
@@ -501,6 +500,7 @@ DEPENDENCIES
   jbuilder
   kamal
   kaminari
+  minitest (~> 5.25)
   pg (~> 1.5)
   propshaft
   puma (>= 5.0)

--- a/app/jobs/rebuild_experiences_job.rb
+++ b/app/jobs/rebuild_experiences_job.rb
@@ -46,7 +46,7 @@ class RebuildExperiencesJob < ApplicationJob
       # Phase 1: Analyze all experiences
       save_status("in_progress", "Analyzing experiences for quality issues...")
       analyzer = Ai::ExperienceAnalyzer.new
-      report = analyzer.generate_report
+      report = analyzer.generate_report(limit: max_rebuilds)
 
       results[:total_analyzed] = report[:total_experiences]
       results[:issues_found] = report[:experiences_with_issues]

--- a/app/services/ai/experience_analyzer.rb
+++ b/app/services/ai/experience_analyzer.rb
@@ -121,8 +121,9 @@ module Ai
     end
 
     # Get a comprehensive report of all quality issues
+    # @param limit [Integer, nil] Maximum number of items to return per category (nil = unlimited)
     # @return [Hash] Report with statistics and issues by type
-    def generate_report
+    def generate_report(limit: 20)
       all_results = []
       similar_experiences = []
 
@@ -144,9 +145,9 @@ module Ai
         similar_experience_pairs: similar_experiences.count,
         issues_by_severity: group_issues_by_severity(all_results),
         issues_by_type: group_issues_by_type(all_results),
-        worst_experiences: experiences_to_rebuild.take(20),
-        deletable_experiences: experiences_to_delete.take(20),
-        similar_experiences: similar_experiences.take(10)
+        worst_experiences: limit ? experiences_to_rebuild.take(limit) : experiences_to_rebuild,
+        deletable_experiences: limit ? experiences_to_delete.take(limit) : experiences_to_delete,
+        similar_experiences: limit ? similar_experiences.take(limit / 2) : similar_experiences
       }
     end
 

--- a/app/services/ai/plan_analyzer.rb
+++ b/app/services/ai/plan_analyzer.rb
@@ -113,8 +113,9 @@ module Ai
     end
 
     # Get a comprehensive report of all quality issues for AI-generated plans
+    # @param limit [Integer, nil] Maximum number of items to return per category (nil = unlimited)
     # @return [Hash] Report with statistics and issues by type
-    def generate_report
+    def generate_report(limit: 20)
       all_results = []
 
       # Only analyze AI-generated plans (user_id is nil)
@@ -136,9 +137,9 @@ module Ai
         similar_plan_pairs: similar_plans.count,
         issues_by_severity: group_issues_by_severity(all_results),
         issues_by_type: group_issues_by_type(all_results),
-        worst_plans: plans_to_rebuild.take(20),
-        deletable_plans: plans_to_delete.take(20),
-        similar_plans: similar_plans.take(10)
+        worst_plans: limit ? plans_to_rebuild.take(limit) : plans_to_rebuild,
+        deletable_plans: limit ? plans_to_delete.take(limit) : plans_to_delete,
+        similar_plans: limit ? similar_plans.take(limit / 2) : similar_plans
       }
     end
 

--- a/app/views/admin/ai/index.html.erb
+++ b/app/views/admin/ai/index.html.erb
@@ -50,16 +50,62 @@
       </ul>
 
       <%= form_with url: admin_generate_admin_ai_path, method: :post, class: "space-y-4" do |f| %>
-        <div class="flex flex-col sm:flex-row items-center justify-center gap-4">
-          <div class="flex items-center gap-2">
-            <label for="max_experiences" class="text-sm text-gray-600">Max experiences:</label>
-            <select name="max_experiences" id="max_experiences" class="rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm">
-              <option value="">Unlimited</option>
-              <option value="5">5</option>
-              <option value="10" selected>10</option>
-              <option value="20">20</option>
-              <option value="50">50</option>
-            </select>
+        <div class="flex flex-col items-center gap-4">
+          <!-- Max limits row -->
+          <div class="flex flex-wrap items-center justify-center gap-4">
+            <div class="flex items-center gap-2">
+              <label for="max_locations" class="text-sm text-gray-600">Max locations:</label>
+              <select name="max_locations" id="max_locations" class="rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm">
+                <option value="0">Unlimited</option>
+                <option value="25">25</option>
+                <option value="50">50</option>
+                <option value="" selected>100 (default)</option>
+                <option value="200">200</option>
+                <option value="500">500</option>
+              </select>
+            </div>
+
+            <div class="flex items-center gap-2">
+              <label for="max_experiences" class="text-sm text-gray-600">Max experiences:</label>
+              <select name="max_experiences" id="max_experiences" class="rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm">
+                <option value="0">Unlimited</option>
+                <option value="25">25</option>
+                <option value="50">50</option>
+                <option value="100">100</option>
+                <option value="" selected>200 (default)</option>
+                <option value="500">500</option>
+              </select>
+            </div>
+
+            <div class="flex items-center gap-2">
+              <label for="max_plans" class="text-sm text-gray-600">Max plans:</label>
+              <select name="max_plans" id="max_plans" class="rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm">
+                <option value="0">Unlimited</option>
+                <option value="10">10</option>
+                <option value="25">25</option>
+                <option value="" selected>50 (default)</option>
+                <option value="100">100</option>
+                <option value="200">200</option>
+              </select>
+            </div>
+          </div>
+
+          <!-- Skip options row -->
+          <div class="flex flex-wrap items-center justify-center gap-4">
+            <label class="flex items-center gap-2 text-sm text-gray-600 cursor-pointer">
+              <input type="checkbox" name="skip_locations" value="1" class="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500">
+              <span>Skip locations</span>
+            </label>
+
+            <label class="flex items-center gap-2 text-sm text-gray-600 cursor-pointer">
+              <input type="checkbox" name="skip_experiences" value="1" class="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500">
+              <span>Skip experiences</span>
+            </label>
+
+            <label class="flex items-center gap-2 text-sm text-gray-600 cursor-pointer">
+              <input type="checkbox" name="skip_plans" value="1" class="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500">
+              <span>Skip plans</span>
+            </label>
           </div>
 
           <button type="submit"
@@ -120,17 +166,22 @@
           <div class="flex flex-wrap items-center justify-center gap-4">
             <label class="flex items-center gap-2 text-sm text-gray-600 cursor-pointer">
               <input type="checkbox" name="regenerate_content" value="1" class="rounded border-gray-300 text-orange-600 focus:ring-orange-500">
-              <span>Regenerate descriptions</span>
+              <span>Regenerate on city change</span>
+            </label>
+
+            <label class="flex items-center gap-2 text-sm text-gray-600 cursor-pointer">
+              <input type="checkbox" name="analyze_descriptions" value="1" class="rounded border-gray-300 text-orange-600 focus:ring-orange-500">
+              <span>Analyze & fix poor descriptions</span>
             </label>
 
             <label class="flex items-center gap-2 text-sm text-gray-600 cursor-pointer">
               <input type="checkbox" name="dry_run" value="1" class="rounded border-gray-300 text-gray-600 focus:ring-gray-500">
-              <span>Preview only (no changes)</span>
+              <span>Preview only</span>
             </label>
 
             <label class="flex items-center gap-2 text-sm text-gray-600 cursor-pointer">
               <input type="checkbox" name="clear_cache" value="1" class="rounded border-gray-300 text-blue-600 focus:ring-blue-500">
-              <span>Clear geocoder cache (fetch fresh data)</span>
+              <span>Clear geocoder cache</span>
             </label>
           </div>
 
@@ -147,7 +198,7 @@
       <% end %>
 
       <p class="text-xs text-gray-400 mt-4 text-center">
-        Note: This process is rate-limited (1 req/sec) to respect Nominatim usage policy.
+        Rate-limited: 1 req/sec for Nominatim, 5 req/sec for Geoapify.
       </p>
     </div>
   </div>
@@ -257,6 +308,7 @@
                 <option value="all">All issues</option>
                 <option value="quality">Quality issues only</option>
                 <option value="similar">Similar experiences only</option>
+                <option value="accommodations">Fix accommodation locations</option>
               </select>
             </div>
 

--- a/db/queue_schema.rb
+++ b/db/queue_schema.rb
@@ -1,0 +1,128 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[8.1].define(version: 2026_01_06_000001) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_catalog.plpgsql"
+
+  create_table "solid_queue_blocked_executions", force: :cascade do |t|
+    t.string "concurrency_key", null: false
+    t.datetime "created_at", null: false
+    t.datetime "expires_at", null: false
+    t.bigint "job_id", null: false
+    t.integer "priority", default: 0, null: false
+    t.string "queue_name", null: false
+    t.index ["concurrency_key", "priority", "job_id"], name: "index_solid_queue_blocked_executions_for_release"
+    t.index ["expires_at", "concurrency_key"], name: "index_solid_queue_blocked_executions_for_maintenance"
+    t.index ["job_id"], name: "index_solid_queue_blocked_executions_on_job_id", unique: true
+  end
+
+  create_table "solid_queue_claimed_executions", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "job_id", null: false
+    t.bigint "process_id"
+    t.index ["job_id"], name: "index_solid_queue_claimed_executions_on_job_id", unique: true
+    t.index ["process_id"], name: "index_solid_queue_claimed_executions_on_process_id"
+  end
+
+  create_table "solid_queue_failed_executions", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.text "error"
+    t.bigint "job_id", null: false
+    t.index ["job_id"], name: "index_solid_queue_failed_executions_on_job_id", unique: true
+  end
+
+  create_table "solid_queue_jobs", force: :cascade do |t|
+    t.string "active_job_id"
+    t.text "arguments"
+    t.string "class_name", null: false
+    t.string "concurrency_key"
+    t.datetime "created_at", null: false
+    t.datetime "finished_at"
+    t.integer "priority", default: 0, null: false
+    t.string "queue_name", null: false
+    t.datetime "scheduled_at"
+    t.datetime "updated_at", null: false
+    t.index ["active_job_id"], name: "index_solid_queue_jobs_on_active_job_id"
+    t.index ["class_name"], name: "index_solid_queue_jobs_on_class_name"
+    t.index ["finished_at"], name: "index_solid_queue_jobs_on_finished_at"
+    t.index ["queue_name", "finished_at"], name: "index_solid_queue_jobs_for_filtering"
+    t.index ["scheduled_at", "finished_at"], name: "index_solid_queue_jobs_for_alerting"
+  end
+
+  create_table "solid_queue_pauses", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "queue_name", null: false
+    t.index ["queue_name"], name: "index_solid_queue_pauses_on_queue_name", unique: true
+  end
+
+  create_table "solid_queue_processes", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "hostname"
+    t.string "kind", null: false
+    t.datetime "last_heartbeat_at", null: false
+    t.text "metadata"
+    t.string "name"
+    t.integer "pid", null: false
+    t.bigint "supervisor_id"
+    t.index ["last_heartbeat_at"], name: "index_solid_queue_processes_on_last_heartbeat_at"
+    t.index ["name", "supervisor_id"], name: "index_solid_queue_processes_on_name_and_supervisor_id", unique: true, where: "(supervisor_id IS NOT NULL)"
+    t.index ["supervisor_id"], name: "index_solid_queue_processes_on_supervisor_id"
+  end
+
+  create_table "solid_queue_ready_executions", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "job_id", null: false
+    t.integer "priority", default: 0, null: false
+    t.string "queue_name", null: false
+    t.index ["job_id"], name: "index_solid_queue_ready_executions_on_job_id", unique: true
+    t.index ["priority", "job_id"], name: "index_solid_queue_poll_all"
+    t.index ["queue_name", "priority", "job_id"], name: "index_solid_queue_poll_by_queue"
+  end
+
+  create_table "solid_queue_recurring_executions", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "job_id", null: false
+    t.datetime "run_at", null: false
+    t.string "task_key", null: false
+    t.index ["job_id"], name: "index_solid_queue_recurring_executions_on_job_id", unique: true
+    t.index ["task_key", "run_at"], name: "index_solid_queue_recurring_executions_on_task_key_and_run_at", unique: true
+  end
+
+  create_table "solid_queue_scheduled_executions", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "job_id", null: false
+    t.integer "priority", default: 0, null: false
+    t.string "queue_name", null: false
+    t.datetime "scheduled_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_scheduled_executions_on_job_id", unique: true
+    t.index ["scheduled_at", "priority", "job_id"], name: "index_solid_queue_dispatch_all"
+  end
+
+  create_table "solid_queue_semaphores", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "expires_at", null: false
+    t.string "key", null: false
+    t.datetime "updated_at", null: false
+    t.integer "value", default: 1, null: false
+    t.index ["expires_at"], name: "index_solid_queue_semaphores_on_expires_at"
+    t.index ["key", "value"], name: "index_solid_queue_semaphores_on_key_and_value"
+    t.index ["key"], name: "index_solid_queue_semaphores_on_key", unique: true
+  end
+
+  add_foreign_key "solid_queue_blocked_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_claimed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_failed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_ready_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_recurring_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_scheduled_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+end

--- a/test/jobs/content_generation_job_test.rb
+++ b/test/jobs/content_generation_job_test.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ContentGenerationJobTest < ActiveJob::TestCase
+  # === Queue configuration tests ===
+
+  test "job is queued in ai_generation queue" do
+    assert_equal "ai_generation", ContentGenerationJob.new.queue_name
+  end
+
+  test "job is enqueued to correct queue" do
+    assert_enqueued_with(job: ContentGenerationJob, queue: "ai_generation") do
+      ContentGenerationJob.perform_later
+    end
+  end
+
+  # === Parameter handling tests ===
+
+  test "job accepts max_locations parameter" do
+    assert_enqueued_with(
+      job: ContentGenerationJob,
+      args: [{ max_locations: 25 }]
+    ) do
+      ContentGenerationJob.perform_later(max_locations: 25)
+    end
+  end
+
+  test "job accepts max_experiences parameter" do
+    assert_enqueued_with(
+      job: ContentGenerationJob,
+      args: [{ max_experiences: 50 }]
+    ) do
+      ContentGenerationJob.perform_later(max_experiences: 50)
+    end
+  end
+
+  test "job accepts max_plans parameter" do
+    assert_enqueued_with(
+      job: ContentGenerationJob,
+      args: [{ max_plans: 10 }]
+    ) do
+      ContentGenerationJob.perform_later(max_plans: 10)
+    end
+  end
+
+  test "job accepts skip_locations parameter" do
+    assert_enqueued_with(
+      job: ContentGenerationJob,
+      args: [{ skip_locations: true }]
+    ) do
+      ContentGenerationJob.perform_later(skip_locations: true)
+    end
+  end
+
+  test "job accepts skip_experiences parameter" do
+    assert_enqueued_with(
+      job: ContentGenerationJob,
+      args: [{ skip_experiences: true }]
+    ) do
+      ContentGenerationJob.perform_later(skip_experiences: true)
+    end
+  end
+
+  test "job accepts skip_plans parameter" do
+    assert_enqueued_with(
+      job: ContentGenerationJob,
+      args: [{ skip_plans: true }]
+    ) do
+      ContentGenerationJob.perform_later(skip_plans: true)
+    end
+  end
+
+  test "job accepts all parameters together" do
+    assert_enqueued_with(
+      job: ContentGenerationJob,
+      args: [{
+        max_locations: 50,
+        max_experiences: 100,
+        max_plans: 25,
+        skip_locations: true,
+        skip_experiences: false,
+        skip_plans: true
+      }]
+    ) do
+      ContentGenerationJob.perform_later(
+        max_locations: 50,
+        max_experiences: 100,
+        max_plans: 25,
+        skip_locations: true,
+        skip_experiences: false,
+        skip_plans: true
+      )
+    end
+  end
+
+  # === Retry configuration tests ===
+
+  test "job has retry_on configured for StandardError" do
+    retry_config = ContentGenerationJob.rescue_handlers.find do |handler|
+      handler[0] == "StandardError"
+    end
+
+    assert_not_nil retry_config, "Should have retry_on for StandardError"
+  end
+
+  test "job discards on GeoapifyService::ConfigurationError" do
+    discard_config = ContentGenerationJob.rescue_handlers.find do |handler|
+      handler[0] == "GeoapifyService::ConfigurationError"
+    end
+
+    assert_not_nil discard_config, "Should have discard_on for GeoapifyService::ConfigurationError"
+  end
+
+  test "job discards on ContentOrchestrator::GenerationError" do
+    discard_config = ContentGenerationJob.rescue_handlers.find do |handler|
+      handler[0] == "Ai::ContentOrchestrator::GenerationError"
+    end
+
+    assert_not_nil discard_config, "Should have discard_on for GenerationError"
+  end
+end

--- a/test/jobs/location_city_fix_job_integration_test.rb
+++ b/test/jobs/location_city_fix_job_integration_test.rb
@@ -1,0 +1,176 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class LocationCityFixJobIntegrationTest < ActiveJob::TestCase
+  setup do
+    # Create test locations with coordinates
+    @location1 = Location.create!(
+      name: "Test Location 1",
+      city: "WrongCity",
+      lat: 43.8563,
+      lng: 18.4131
+    )
+
+    @location2 = Location.create!(
+      name: "Test Location 2",
+      city: "AnotherWrongCity",
+      lat: 43.8570,
+      lng: 18.4150
+    )
+  end
+
+  teardown do
+    LocationCityFixJob.clear_status!
+  end
+
+  # === Rate limiting constants tests ===
+
+  test "GEOAPIFY_SLEEP is 0.2 seconds (5 req/s)" do
+    assert_equal 0.2, LocationCityFixJob::GEOAPIFY_SLEEP
+  end
+
+  test "NOMINATIM_SLEEP is 1.1 seconds (1 req/s with buffer)" do
+    assert_equal 1.1, LocationCityFixJob::NOMINATIM_SLEEP
+  end
+
+  test "Geoapify is faster than Nominatim" do
+    assert LocationCityFixJob::GEOAPIFY_SLEEP < LocationCityFixJob::NOMINATIM_SLEEP
+  end
+
+  test "Nominatim rate limit respects 1 request per second" do
+    assert LocationCityFixJob::NOMINATIM_SLEEP > 1.0, "Nominatim needs > 1s delay (1 req/s limit)"
+  end
+
+  # === get_city_from_coordinates source detection tests ===
+
+  test "get_city_from_coordinates returns override source for Zvornik coordinates" do
+    job = LocationCityFixJob.new
+
+    # Use coordinates that match the COORDINATE_OVERRIDES (Zvornik area)
+    result = job.send(:get_city_from_coordinates, 44.40, 19.10)
+
+    assert_equal "Zvornik", result[:city]
+    assert_equal :override, result[:source]
+  end
+
+  test "get_city_from_coordinates returns nil for blank coordinates" do
+    job = LocationCityFixJob.new
+
+    result = job.send(:get_city_from_coordinates, nil, nil)
+
+    assert_nil result[:city]
+    assert_nil result[:source]
+  end
+
+  test "get_city_from_coordinates returns nil for empty lat" do
+    job = LocationCityFixJob.new
+
+    result = job.send(:get_city_from_coordinates, "", 18.4131)
+
+    assert_nil result[:city]
+    assert_nil result[:source]
+  end
+
+  # === Coordinate override tests ===
+
+  test "check_coordinate_overrides returns Zvornik for matching coordinates" do
+    job = LocationCityFixJob.new
+
+    # Within Zvornik override range
+    result = job.send(:check_coordinate_overrides, 44.40, 19.10)
+    assert_equal "Zvornik", result
+
+    # Outside override range
+    result = job.send(:check_coordinate_overrides, 43.85, 18.41)
+    assert_nil result
+  end
+
+  test "COORDINATE_OVERRIDES includes Zvornik area" do
+    overrides = LocationCityFixJob::COORDINATE_OVERRIDES
+
+    zvornik_override = overrides.find { |o| o[:city] == "Zvornik" }
+    assert_not_nil zvornik_override, "Should have Zvornik coordinate override"
+    assert zvornik_override[:lat_range].is_a?(Range)
+    assert zvornik_override[:lng_range].is_a?(Range)
+  end
+
+  # === Status methods tests ===
+
+  test "current_status returns hash with expected keys" do
+    status = LocationCityFixJob.current_status
+
+    assert status.is_a?(Hash)
+    assert_includes status.keys, :status
+    assert_includes status.keys, :message
+    assert_includes status.keys, :results
+  end
+
+  test "clear_status! resets to idle" do
+    Setting.set("location_fix.status", "in_progress")
+
+    LocationCityFixJob.clear_status!
+
+    status = LocationCityFixJob.current_status
+    assert_equal "idle", status[:status]
+  end
+
+  test "force_reset_city_fix! resets stuck job" do
+    Setting.set("location_fix.status", "in_progress")
+
+    LocationCityFixJob.force_reset_city_fix!
+
+    status = LocationCityFixJob.current_status
+    assert_equal "idle", status[:status]
+  end
+
+  # === City comparison tests ===
+
+  test "cities_different? returns true for blank vs present" do
+    job = LocationCityFixJob.new
+
+    assert job.send(:cities_different?, "", "Sarajevo")
+    assert job.send(:cities_different?, nil, "Sarajevo")
+  end
+
+  test "cities_different? returns false for same city (case insensitive)" do
+    job = LocationCityFixJob.new
+
+    refute job.send(:cities_different?, "Sarajevo", "sarajevo")
+    refute job.send(:cities_different?, "SARAJEVO", "Sarajevo")
+  end
+
+  test "cities_different? handles special characters" do
+    job = LocationCityFixJob.new
+
+    # Same city with different formatting
+    refute job.send(:cities_different?, "Banja Luka", "Banja Luka")
+  end
+
+  # === City name cleaning tests ===
+
+  test "clean_city_name removes Grad prefix" do
+    job = LocationCityFixJob.new
+
+    assert_equal "Zvornik", job.send(:clean_city_name, "Grad Zvornik")
+    assert_equal "Sarajevo", job.send(:clean_city_name, "Grad Sarajevo")
+  end
+
+  test "clean_city_name removes Općina prefix" do
+    job = LocationCityFixJob.new
+
+    assert_equal "Mostar", job.send(:clean_city_name, "Općina Mostar")
+  end
+
+  test "clean_city_name removes Opština prefix" do
+    job = LocationCityFixJob.new
+
+    assert_equal "Banja Luka", job.send(:clean_city_name, "Opština Banja Luka")
+  end
+
+  test "clean_city_name removes Municipality of prefix" do
+    job = LocationCityFixJob.new
+
+    assert_equal "Sarajevo", job.send(:clean_city_name, "Municipality of Sarajevo")
+  end
+end

--- a/test/jobs/location_city_fix_job_test.rb
+++ b/test/jobs/location_city_fix_job_test.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class LocationCityFixJobTest < ActiveJob::TestCase
+  # === Queue configuration tests ===
+
+  test "job is queued in default queue" do
+    assert_equal "default", LocationCityFixJob.new.queue_name
+  end
+
+  test "job is enqueued with parameters" do
+    assert_enqueued_with(
+      job: LocationCityFixJob,
+      args: [{ regenerate_content: true, dry_run: false }]
+    ) do
+      LocationCityFixJob.perform_later(regenerate_content: true, dry_run: false)
+    end
+  end
+
+  # === Rate limit constants tests ===
+
+  test "GEOAPIFY_SLEEP is defined as 0.2 seconds" do
+    assert_equal 0.2, LocationCityFixJob::GEOAPIFY_SLEEP
+  end
+
+  test "NOMINATIM_SLEEP is defined as 1.1 seconds" do
+    assert_equal 1.1, LocationCityFixJob::NOMINATIM_SLEEP
+  end
+
+  test "GEOAPIFY_SLEEP is faster than NOMINATIM_SLEEP" do
+    assert LocationCityFixJob::GEOAPIFY_SLEEP < LocationCityFixJob::NOMINATIM_SLEEP
+  end
+
+  # === Retry configuration tests ===
+
+  test "job has retry_on configured for StandardError" do
+    retry_config = LocationCityFixJob.rescue_handlers.find do |handler|
+      handler[0] == "StandardError"
+    end
+
+    assert_not_nil retry_config, "Should have retry_on for StandardError"
+  end
+
+  # === Status methods tests ===
+
+  test "current_status returns hash with expected keys" do
+    status = LocationCityFixJob.current_status
+
+    assert status.is_a?(Hash)
+    assert_includes status.keys, :status
+    assert_includes status.keys, :message
+    assert_includes status.keys, :results
+  end
+
+  test "clear_status! resets status to idle" do
+    Setting.set("location_fix.status", "in_progress")
+    Setting.set("location_fix.message", "Working...")
+
+    LocationCityFixJob.clear_status!
+
+    status = LocationCityFixJob.current_status
+    assert_equal "idle", status[:status]
+    # Message is cleared to empty string or nil
+    assert_includes [nil, ""], status[:message]
+  end
+
+  test "force_reset_city_fix! resets stuck job" do
+    Setting.set("location_fix.status", "in_progress")
+
+    LocationCityFixJob.force_reset_city_fix!
+
+    status = LocationCityFixJob.current_status
+    assert_equal "idle", status[:status]
+  end
+end

--- a/test/jobs/openai_request_job_test.rb
+++ b/test/jobs/openai_request_job_test.rb
@@ -132,12 +132,12 @@ class OpenaiRequestJobTest < ActiveJob::TestCase
       attempts += 1
       raise Ai::OpenaiQueue::RequestError, "API failed"
     } do
-      assert_raises(Ai::OpenaiQueue::RequestError) do
-        OpenaiRequestJob.perform_now(prompt: "Test", context: "Test")
-      end
+      # With retry_on, perform_now catches the error and schedules retry
+      # The error is not re-raised to the caller
+      OpenaiRequestJob.perform_now(prompt: "Test", context: "Test")
     end
 
-    assert_equal 1, attempts
+    assert_equal 1, attempts, "Request should have been attempted once"
   end
 
   test "job retries on RateLimitError" do
@@ -147,12 +147,12 @@ class OpenaiRequestJobTest < ActiveJob::TestCase
       attempts += 1
       raise Ai::OpenaiQueue::RateLimitError, "Rate limited"
     } do
-      assert_raises(Ai::OpenaiQueue::RateLimitError) do
-        OpenaiRequestJob.perform_now(prompt: "Test", context: "Test")
-      end
+      # With retry_on, perform_now catches the error and schedules retry
+      # The error is not re-raised to the caller
+      OpenaiRequestJob.perform_now(prompt: "Test", context: "Test")
     end
 
-    assert_equal 1, attempts
+    assert_equal 1, attempts, "Request should have been attempted once"
   end
 
   # === Retry configuration tests ===

--- a/test/jobs/rebuild_experiences_job_test.rb
+++ b/test/jobs/rebuild_experiences_job_test.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class RebuildExperiencesJobTest < ActiveJob::TestCase
+  # === Queue configuration tests ===
+
+  test "job is queued in ai_generation queue" do
+    assert_equal "ai_generation", RebuildExperiencesJob.new.queue_name
+  end
+
+  test "job is enqueued with parameters" do
+    assert_enqueued_with(
+      job: RebuildExperiencesJob,
+      args: [{ dry_run: true, rebuild_mode: "quality", max_rebuilds: 10 }]
+    ) do
+      RebuildExperiencesJob.perform_later(dry_run: true, rebuild_mode: "quality", max_rebuilds: 10)
+    end
+  end
+
+  # === Constants tests ===
+
+  test "MODES includes all valid modes" do
+    assert_includes RebuildExperiencesJob::MODES, "all"
+    assert_includes RebuildExperiencesJob::MODES, "quality"
+    assert_includes RebuildExperiencesJob::MODES, "similar"
+  end
+
+  # === Retry configuration tests ===
+
+  test "job has retry_on configured for StandardError" do
+    retry_config = RebuildExperiencesJob.rescue_handlers.find do |handler|
+      handler[0] == "StandardError"
+    end
+
+    assert_not_nil retry_config, "Should have retry_on for StandardError"
+  end
+
+  # === Status methods tests ===
+
+  test "current_status returns hash with expected keys" do
+    status = RebuildExperiencesJob.current_status
+
+    assert status.is_a?(Hash)
+    assert_includes status.keys, :status
+    assert_includes status.keys, :message
+    assert_includes status.keys, :results
+  end
+
+  test "clear_status! resets status to idle" do
+    Setting.set("rebuild_experiences.status", "in_progress")
+    Setting.set("rebuild_experiences.message", "Working...")
+
+    RebuildExperiencesJob.clear_status!
+
+    status = RebuildExperiencesJob.current_status
+    assert_equal "idle", status[:status]
+  end
+
+  test "force_reset! resets stuck job" do
+    Setting.set("rebuild_experiences.status", "in_progress")
+
+    RebuildExperiencesJob.force_reset!
+
+    status = RebuildExperiencesJob.current_status
+    assert_equal "idle", status[:status]
+  end
+end

--- a/test/jobs/rebuild_plans_job_integration_test.rb
+++ b/test/jobs/rebuild_plans_job_integration_test.rb
@@ -1,0 +1,297 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class RebuildPlansJobIntegrationTest < ActiveJob::TestCase
+  setup do
+    @city = "Sarajevo"
+
+    # Create a location for experiences
+    @location = Location.create!(
+      name: "Test Location",
+      city: @city,
+      lat: 43.8563,
+      lng: 18.4131
+    )
+
+    # Create experience category
+    @category = ExperienceCategory.find_or_create_by!(key: "culture") do |cat|
+      cat.name = "Culture"
+    end
+
+    # Create current experiences in the plan
+    @experience1 = Experience.create!(title: "Museum Visit", experience_category: @category)
+    @experience1.add_location(@location)
+
+    @experience2 = Experience.create!(title: "Walking Tour", experience_category: @category)
+    @experience2.add_location(@location)
+
+    # Create available replacement experiences
+    @replacement_exp1 = Experience.create!(title: "Food Tour", experience_category: @category)
+    @replacement_exp1.add_location(@location)
+
+    @replacement_exp2 = Experience.create!(title: "Historical Walk", experience_category: @category)
+    @replacement_exp2.add_location(@location)
+
+    # Create AI-generated plan (user_id is nil)
+    @plan = Plan.create!(
+      title: "Test Plan",
+      city_name: @city,
+      user_id: nil,
+      preferences: { "tourist_profile" => "family" }
+    )
+
+    # Add experiences to plan
+    @plan.plan_experiences.create!(experience: @experience1, day_number: 1, position: 1)
+    @plan.plan_experiences.create!(experience: @experience2, day_number: 2, position: 1)
+  end
+
+  teardown do
+    RebuildPlansJob.clear_status!
+  end
+
+  # === Experience replacement threshold tests ===
+
+  test "EXPERIENCE_REBUILD_THRESHOLD is 50" do
+    assert_equal 50, RebuildPlansJob::EXPERIENCE_REBUILD_THRESHOLD
+  end
+
+  test "score below threshold triggers experience rebuild call in rebuild_plan" do
+    job = RebuildPlansJob.new
+
+    # Track whether rebuild_experiences_for_plan is called
+    experience_rebuild_called = false
+
+    # Redefine the method to track calls
+    original_method = job.method(:rebuild_experiences_for_plan)
+    job.define_singleton_method(:rebuild_experiences_for_plan) do |plan, experiences|
+      experience_rebuild_called = true
+      # Don't actually run it to avoid AI calls
+    end
+
+    issues = [{ type: :short_notes, message: "Notes too short" }]
+    score = 30 # Below threshold of 50
+
+    # Also stub the AI call for content regeneration
+    ai_content_response = {
+      titles: { "en" => "New Title", "bs" => "Novi Naslov" },
+      notes: { "en" => "New notes for the plan", "bs" => "Nove bilješke za plan" }
+    }
+
+    Ai::OpenaiQueue.stub(:request, ai_content_response) do
+      job.send(:rebuild_plan, @plan.id, issues, score)
+    end
+
+    assert experience_rebuild_called, "rebuild_experiences_for_plan should be called for score < 50"
+  end
+
+  test "score at or above threshold does not trigger experience rebuild" do
+    job = RebuildPlansJob.new
+
+    experience_rebuild_called = false
+
+    job.define_singleton_method(:rebuild_experiences_for_plan) do |plan, experiences|
+      experience_rebuild_called = true
+    end
+
+    issues = [{ type: :short_notes, message: "Notes too short" }]
+    score = 60 # Above threshold of 50
+
+    ai_content_response = {
+      titles: { "en" => "New Title", "bs" => "Novi Naslov" },
+      notes: { "en" => "New notes for the plan", "bs" => "Nove bilješke za plan" }
+    }
+
+    Ai::OpenaiQueue.stub(:request, ai_content_response) do
+      job.send(:rebuild_plan, @plan.id, issues, score)
+    end
+
+    assert_not experience_rebuild_called, "rebuild_experiences_for_plan should NOT be called for score >= 50"
+  end
+
+  test "score exactly at threshold (50) does not trigger experience rebuild" do
+    job = RebuildPlansJob.new
+
+    experience_rebuild_called = false
+
+    job.define_singleton_method(:rebuild_experiences_for_plan) do |plan, experiences|
+      experience_rebuild_called = true
+    end
+
+    issues = [{ type: :short_notes, message: "Notes too short" }]
+    score = 50 # Exactly at threshold
+
+    ai_content_response = {
+      titles: { "en" => "New Title", "bs" => "Novi Naslov" },
+      notes: { "en" => "New notes", "bs" => "Nove bilješke" }
+    }
+
+    Ai::OpenaiQueue.stub(:request, ai_content_response) do
+      job.send(:rebuild_plan, @plan.id, issues, score)
+    end
+
+    assert_not experience_rebuild_called, "rebuild_experiences_for_plan should NOT be called for score = 50"
+  end
+
+  # === apply_experience_replacements tests ===
+
+  test "apply_experience_replacements preserves day_number and position" do
+    # Get original plan_experience details
+    original_pe = @plan.plan_experiences.find_by(experience: @experience1)
+    original_day = original_pe.day_number
+    original_position = original_pe.position
+
+    # Create the job and call the private method directly
+    job = RebuildPlansJob.new
+
+    replacements = [
+      {
+        remove_experience_id: @experience1.id,
+        add_experience_id: @replacement_exp1.id,
+        reason: "Test replacement"
+      }
+    ]
+
+    available = [@replacement_exp1, @replacement_exp2]
+
+    job.send(:apply_experience_replacements, @plan, replacements, available)
+
+    # Verify replacement preserves day and position
+    @plan.reload
+    new_pe = @plan.plan_experiences.find_by(experience: @replacement_exp1)
+
+    assert_not_nil new_pe, "Replacement experience should be added to plan"
+    assert_equal original_day, new_pe.day_number, "Day number should be preserved"
+    assert_equal original_position, new_pe.position, "Position should be preserved"
+
+    # Verify original experience is removed
+    assert_nil @plan.plan_experiences.find_by(experience: @experience1), "Original experience should be removed"
+  end
+
+  test "apply_experience_replacements validates replacement experience exists in available list" do
+    job = RebuildPlansJob.new
+
+    # Try to replace with an experience not in available list
+    other_experience = Experience.create!(title: "Other Experience")
+
+    replacements = [
+      {
+        remove_experience_id: @experience1.id,
+        add_experience_id: other_experience.id, # Not in available list
+        reason: "Test replacement"
+      }
+    ]
+
+    # Only @replacement_exp1 in available list
+    available = [@replacement_exp1]
+
+    job.send(:apply_experience_replacements, @plan, replacements, available)
+
+    # Verify replacement did NOT happen (experience not in available list)
+    @plan.reload
+    assert @plan.plan_experiences.find_by(experience: @experience1).present?, "Original should remain if replacement not available"
+    assert_nil @plan.plan_experiences.find_by(experience: other_experience), "Unavailable replacement should not be added"
+  end
+
+  test "apply_experience_replacements handles multiple replacements" do
+    job = RebuildPlansJob.new
+
+    original_pe1 = @plan.plan_experiences.find_by(experience: @experience1)
+    original_pe2 = @plan.plan_experiences.find_by(experience: @experience2)
+
+    replacements = [
+      {
+        remove_experience_id: @experience1.id,
+        add_experience_id: @replacement_exp1.id,
+        reason: "First replacement"
+      },
+      {
+        remove_experience_id: @experience2.id,
+        add_experience_id: @replacement_exp2.id,
+        reason: "Second replacement"
+      }
+    ]
+
+    available = [@replacement_exp1, @replacement_exp2]
+
+    job.send(:apply_experience_replacements, @plan, replacements, available)
+
+    @plan.reload
+
+    # Verify both replacements happened
+    new_pe1 = @plan.plan_experiences.find_by(experience: @replacement_exp1)
+    new_pe2 = @plan.plan_experiences.find_by(experience: @replacement_exp2)
+
+    assert_not_nil new_pe1
+    assert_not_nil new_pe2
+    assert_equal original_pe1.day_number, new_pe1.day_number
+    assert_equal original_pe2.day_number, new_pe2.day_number
+  end
+
+  test "rebuild_experiences_for_plan respects keep_all=true" do
+    job = RebuildPlansJob.new
+
+    original_experience_ids = @plan.experiences.pluck(:id).sort
+
+    # AI decides to keep all experiences
+    ai_replacement_response = {
+      keep_all: true,
+      replacements: [],
+      reasoning: "All experiences fit the profile well"
+    }
+
+    Ai::OpenaiQueue.stub(:request, ai_replacement_response) do
+      job.send(:rebuild_experiences_for_plan, @plan, @plan.experiences.to_a)
+    end
+
+    @plan.reload
+    assert_equal original_experience_ids, @plan.experiences.pluck(:id).sort, "All experiences should be preserved when AI decides keep_all"
+  end
+
+  # === User-owned plans should never be modified ===
+
+  test "rebuild_plan returns false for user-owned plans" do
+    # Create user-owned plan
+    user = User.create!(username: "testuser", password: "password123")
+    user_plan = Plan.create!(
+      title: "User Plan",
+      city_name: @city,
+      user: user
+    )
+    user_plan.plan_experiences.create!(experience: @experience1, day_number: 1, position: 1)
+
+    original_experience_ids = user_plan.experiences.pluck(:id)
+    issues = [{ type: :missing_notes, message: "No notes" }]
+    score = 10 # Very low score
+
+    job = RebuildPlansJob.new
+
+    # rebuild_plan should return false for user-owned plans without doing anything
+    result = job.send(:rebuild_plan, user_plan.id, issues, score)
+
+    assert_equal false, result, "rebuild_plan should return false for user-owned plans"
+
+    user_plan.reload
+    assert_equal original_experience_ids, user_plan.experiences.pluck(:id), "User plan experiences should remain unchanged"
+  end
+
+  # === Status methods tests ===
+
+  test "current_status returns hash with expected keys" do
+    status = RebuildPlansJob.current_status
+
+    assert status.is_a?(Hash)
+    assert_includes status.keys, :status
+    assert_includes status.keys, :message
+    assert_includes status.keys, :results
+  end
+
+  test "clear_status! resets status to idle" do
+    Setting.set("rebuild_plans.status", "in_progress")
+
+    RebuildPlansJob.clear_status!
+
+    status = RebuildPlansJob.current_status
+    assert_equal "idle", status[:status]
+  end
+end

--- a/test/jobs/rebuild_plans_job_test.rb
+++ b/test/jobs/rebuild_plans_job_test.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class RebuildPlansJobTest < ActiveJob::TestCase
+  # === Queue configuration tests ===
+
+  test "job is queued in ai_generation queue" do
+    assert_equal "ai_generation", RebuildPlansJob.new.queue_name
+  end
+
+  test "job is enqueued with parameters" do
+    assert_enqueued_with(
+      job: RebuildPlansJob,
+      args: [{ dry_run: true, rebuild_mode: "quality", max_rebuilds: 10 }]
+    ) do
+      RebuildPlansJob.perform_later(dry_run: true, rebuild_mode: "quality", max_rebuilds: 10)
+    end
+  end
+
+  # === Constants tests ===
+
+  test "EXPERIENCE_REBUILD_THRESHOLD is defined" do
+    assert_equal 50, RebuildPlansJob::EXPERIENCE_REBUILD_THRESHOLD
+  end
+
+  test "MODES includes all valid modes" do
+    assert_includes RebuildPlansJob::MODES, "all"
+    assert_includes RebuildPlansJob::MODES, "quality"
+    assert_includes RebuildPlansJob::MODES, "similar"
+  end
+
+  # === Retry configuration tests ===
+
+  test "job has retry_on configured for StandardError" do
+    retry_config = RebuildPlansJob.rescue_handlers.find do |handler|
+      handler[0] == "StandardError"
+    end
+
+    assert_not_nil retry_config, "Should have retry_on for StandardError"
+  end
+end

--- a/test/services/ai/content_orchestrator_integration_test.rb
+++ b/test/services/ai/content_orchestrator_integration_test.rb
@@ -1,0 +1,314 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Ai
+  class ContentOrchestratorIntegrationTest < ActiveSupport::TestCase
+    setup do
+      # Clear any generation status
+      Ai::ContentOrchestrator.force_reset!
+    end
+
+    teardown do
+      Ai::ContentOrchestrator.force_reset!
+    end
+
+    # === Skip options tests ===
+    # These tests verify that skip options are properly passed and stored
+
+    test "skip options are stored correctly in results" do
+      GeoapifyService.stub(:new, -> { Object.new }) do
+        orchestrator = Ai::ContentOrchestrator.new(
+          skip_locations: true,
+          skip_experiences: false,
+          skip_plans: true
+        )
+
+        results = orchestrator.instance_variable_get(:@results)
+
+        assert results[:skipped][:locations], "Should indicate locations are skipped"
+        assert_not results[:skipped][:experiences], "Should indicate experiences are NOT skipped"
+        assert results[:skipped][:plans], "Should indicate plans are skipped"
+      end
+    end
+
+    test "skip_locations flag is stored in instance variable" do
+      GeoapifyService.stub(:new, -> { Object.new }) do
+        orchestrator = Ai::ContentOrchestrator.new(skip_locations: true)
+        assert orchestrator.instance_variable_get(:@skip_locations)
+      end
+    end
+
+    test "skip_experiences flag is stored in instance variable" do
+      GeoapifyService.stub(:new, -> { Object.new }) do
+        orchestrator = Ai::ContentOrchestrator.new(skip_experiences: true)
+        assert orchestrator.instance_variable_get(:@skip_experiences)
+      end
+    end
+
+    test "skip_plans flag is stored in instance variable" do
+      GeoapifyService.stub(:new, -> { Object.new }) do
+        orchestrator = Ai::ContentOrchestrator.new(skip_plans: true)
+        assert orchestrator.instance_variable_get(:@skip_plans)
+      end
+    end
+
+    # === Default max_experiences tests ===
+
+    test "default max_experiences is 200 when nil is passed" do
+      GeoapifyService.stub(:new, -> { Object.new }) do
+        orchestrator = Ai::ContentOrchestrator.new(max_experiences: nil)
+
+        assert_equal 200, orchestrator.instance_variable_get(:@max_experiences)
+      end
+    end
+
+    test "custom max_experiences is respected" do
+      GeoapifyService.stub(:new, -> { Object.new }) do
+        orchestrator = Ai::ContentOrchestrator.new(max_experiences: 50)
+
+        assert_equal 50, orchestrator.instance_variable_get(:@max_experiences)
+      end
+    end
+
+    test "experiences_limit_reached is true when at max" do
+      GeoapifyService.stub(:new, -> { Object.new }) do
+        orchestrator = Ai::ContentOrchestrator.new(max_experiences: 2)
+
+        # Simulate already having created 2 experiences
+        orchestrator.instance_variable_get(:@results)[:experiences_created] = 2
+
+        # Should be at limit
+        assert orchestrator.send(:experiences_limit_reached?)
+      end
+    end
+
+    test "experiences_limit_reached is false when under max" do
+      GeoapifyService.stub(:new, -> { Object.new }) do
+        orchestrator = Ai::ContentOrchestrator.new(max_experiences: 10)
+
+        # Simulate having created 5 experiences
+        orchestrator.instance_variable_get(:@results)[:experiences_created] = 5
+
+        # Should not be at limit
+        refute orchestrator.send(:experiences_limit_reached?)
+      end
+    end
+
+    test "remaining_experience_slots calculates correctly" do
+      GeoapifyService.stub(:new, -> { Object.new }) do
+        orchestrator = Ai::ContentOrchestrator.new(max_experiences: 10)
+
+        orchestrator.instance_variable_get(:@results)[:experiences_created] = 3
+
+        assert_equal 7, orchestrator.send(:remaining_experience_slots)
+      end
+    end
+
+    test "remaining_experience_slots returns 0 when over limit" do
+      GeoapifyService.stub(:new, -> { Object.new }) do
+        orchestrator = Ai::ContentOrchestrator.new(max_experiences: 5)
+
+        # Simulate having created more than max
+        orchestrator.instance_variable_get(:@results)[:experiences_created] = 10
+
+        assert_equal 0, orchestrator.send(:remaining_experience_slots)
+      end
+    end
+
+    # === Default max_locations tests ===
+
+    test "default max_locations is 100 when nil is passed" do
+      GeoapifyService.stub(:new, -> { Object.new }) do
+        orchestrator = Ai::ContentOrchestrator.new(max_locations: nil)
+
+        assert_equal 100, orchestrator.instance_variable_get(:@max_locations)
+      end
+    end
+
+    test "custom max_locations is respected" do
+      GeoapifyService.stub(:new, -> { Object.new }) do
+        orchestrator = Ai::ContentOrchestrator.new(max_locations: 25)
+
+        assert_equal 25, orchestrator.instance_variable_get(:@max_locations)
+      end
+    end
+
+    test "max_locations 0 means unlimited (nil)" do
+      GeoapifyService.stub(:new, -> { Object.new }) do
+        orchestrator = Ai::ContentOrchestrator.new(max_locations: 0)
+
+        assert_nil orchestrator.instance_variable_get(:@max_locations)
+      end
+    end
+
+    test "locations_limit_reached is true when at max" do
+      GeoapifyService.stub(:new, -> { Object.new }) do
+        orchestrator = Ai::ContentOrchestrator.new(max_locations: 5)
+
+        orchestrator.instance_variable_get(:@results)[:locations_created] = 5
+
+        assert orchestrator.send(:locations_limit_reached?)
+      end
+    end
+
+    test "locations_limit_reached is false when under max" do
+      GeoapifyService.stub(:new, -> { Object.new }) do
+        orchestrator = Ai::ContentOrchestrator.new(max_locations: 10)
+
+        orchestrator.instance_variable_get(:@results)[:locations_created] = 3
+
+        refute orchestrator.send(:locations_limit_reached?)
+      end
+    end
+
+    test "locations_limit_reached is false when unlimited" do
+      GeoapifyService.stub(:new, -> { Object.new }) do
+        orchestrator = Ai::ContentOrchestrator.new(max_locations: 0)
+
+        orchestrator.instance_variable_get(:@results)[:locations_created] = 1000
+
+        refute orchestrator.send(:locations_limit_reached?)
+      end
+    end
+
+    test "remaining_location_slots calculates correctly" do
+      GeoapifyService.stub(:new, -> { Object.new }) do
+        orchestrator = Ai::ContentOrchestrator.new(max_locations: 10)
+
+        orchestrator.instance_variable_get(:@results)[:locations_created] = 3
+
+        assert_equal 7, orchestrator.send(:remaining_location_slots)
+      end
+    end
+
+    # === Default max_plans tests ===
+
+    test "default max_plans is 50 when nil is passed" do
+      GeoapifyService.stub(:new, -> { Object.new }) do
+        orchestrator = Ai::ContentOrchestrator.new(max_plans: nil)
+
+        assert_equal 50, orchestrator.instance_variable_get(:@max_plans)
+      end
+    end
+
+    test "custom max_plans is respected" do
+      GeoapifyService.stub(:new, -> { Object.new }) do
+        orchestrator = Ai::ContentOrchestrator.new(max_plans: 25)
+
+        assert_equal 25, orchestrator.instance_variable_get(:@max_plans)
+      end
+    end
+
+    test "max_plans 0 means unlimited (nil)" do
+      GeoapifyService.stub(:new, -> { Object.new }) do
+        orchestrator = Ai::ContentOrchestrator.new(max_plans: 0)
+
+        assert_nil orchestrator.instance_variable_get(:@max_plans)
+      end
+    end
+
+    test "plans_limit_reached is true when at max" do
+      GeoapifyService.stub(:new, -> { Object.new }) do
+        orchestrator = Ai::ContentOrchestrator.new(max_plans: 5)
+
+        orchestrator.instance_variable_get(:@results)[:plans_created] = 5
+
+        assert orchestrator.send(:plans_limit_reached?)
+      end
+    end
+
+    test "plans_limit_reached is false when under max" do
+      GeoapifyService.stub(:new, -> { Object.new }) do
+        orchestrator = Ai::ContentOrchestrator.new(max_plans: 10)
+
+        orchestrator.instance_variable_get(:@results)[:plans_created] = 3
+
+        refute orchestrator.send(:plans_limit_reached?)
+      end
+    end
+
+    test "plans_limit_reached is false when unlimited" do
+      GeoapifyService.stub(:new, -> { Object.new }) do
+        orchestrator = Ai::ContentOrchestrator.new(max_plans: 0)
+
+        orchestrator.instance_variable_get(:@results)[:plans_created] = 1000
+
+        refute orchestrator.send(:plans_limit_reached?)
+      end
+    end
+
+    test "remaining_plan_slots calculates correctly" do
+      GeoapifyService.stub(:new, -> { Object.new }) do
+        orchestrator = Ai::ContentOrchestrator.new(max_plans: 10)
+
+        orchestrator.instance_variable_get(:@results)[:plans_created] = 3
+
+        assert_equal 7, orchestrator.send(:remaining_plan_slots)
+      end
+    end
+
+    test "max_experiences 0 means unlimited (nil)" do
+      GeoapifyService.stub(:new, -> { Object.new }) do
+        orchestrator = Ai::ContentOrchestrator.new(max_experiences: 0)
+
+        assert_nil orchestrator.instance_variable_get(:@max_experiences)
+      end
+    end
+
+    # === Constants tests ===
+
+    test "DEFAULT_MAX_LOCATIONS is 100" do
+      assert_equal 100, Ai::ContentOrchestrator::DEFAULT_MAX_LOCATIONS
+    end
+
+    test "DEFAULT_MAX_EXPERIENCES is 200" do
+      assert_equal 200, Ai::ContentOrchestrator::DEFAULT_MAX_EXPERIENCES
+    end
+
+    test "DEFAULT_MAX_PLANS is 50" do
+      assert_equal 50, Ai::ContentOrchestrator::DEFAULT_MAX_PLANS
+    end
+
+    # === Status methods tests ===
+
+    test "current_status returns hash with expected keys" do
+      status = Ai::ContentOrchestrator.current_status
+
+      assert status.is_a?(Hash)
+      assert_includes status.keys, :status
+      assert_includes status.keys, :message
+      assert_includes status.keys, :started_at
+      assert_includes status.keys, :plan
+      assert_includes status.keys, :results
+    end
+
+    test "force_reset! resets status to idle" do
+      Setting.set("ai.generation.status", "in_progress")
+      Setting.set("ai.generation.cancelled", "true")
+
+      Ai::ContentOrchestrator.force_reset!
+
+      assert_equal "idle", Setting.get("ai.generation.status")
+      assert_equal "false", Setting.get("ai.generation.cancelled")
+    end
+
+    test "cancel_generation! sets cancelled flag" do
+      Ai::ContentOrchestrator.clear_cancellation!
+      assert_equal false, Ai::ContentOrchestrator.cancelled?
+
+      Ai::ContentOrchestrator.cancel_generation!
+
+      assert_equal true, Ai::ContentOrchestrator.cancelled?
+    end
+
+    test "clear_cancellation! clears cancelled flag" do
+      Ai::ContentOrchestrator.cancel_generation!
+      assert_equal true, Ai::ContentOrchestrator.cancelled?
+
+      Ai::ContentOrchestrator.clear_cancellation!
+
+      assert_equal false, Ai::ContentOrchestrator.cancelled?
+    end
+  end
+end

--- a/test/services/ai/content_orchestrator_test.rb
+++ b/test/services/ai/content_orchestrator_test.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Ai
+  class ContentOrchestratorTest < ActiveSupport::TestCase
+    # === Constants tests ===
+
+    test "DEFAULT_MAX_EXPERIENCES is defined as 200" do
+      assert_equal 200, Ai::ContentOrchestrator::DEFAULT_MAX_EXPERIENCES
+    end
+
+    # === Status methods tests ===
+
+    test "current_status returns hash with expected keys" do
+      status = Ai::ContentOrchestrator.current_status
+
+      assert status.is_a?(Hash)
+      assert_includes status.keys, :status
+      assert_includes status.keys, :message
+      assert_includes status.keys, :started_at
+      assert_includes status.keys, :plan
+      assert_includes status.keys, :results
+    end
+
+    test "cancel_generation! sets cancelled flag" do
+      Ai::ContentOrchestrator.clear_cancellation!
+      assert_equal false, Ai::ContentOrchestrator.cancelled?
+
+      Ai::ContentOrchestrator.cancel_generation!
+
+      assert_equal true, Ai::ContentOrchestrator.cancelled?
+    end
+
+    test "clear_cancellation! clears cancelled flag" do
+      Ai::ContentOrchestrator.cancel_generation!
+      assert_equal true, Ai::ContentOrchestrator.cancelled?
+
+      Ai::ContentOrchestrator.clear_cancellation!
+
+      assert_equal false, Ai::ContentOrchestrator.cancelled?
+    end
+
+    test "force_reset! resets all status" do
+      Setting.set("ai.generation.status", "in_progress")
+      Setting.set("ai.generation.cancelled", "true")
+
+      Ai::ContentOrchestrator.force_reset!
+
+      assert_equal "idle", Setting.get("ai.generation.status")
+      assert_equal "false", Setting.get("ai.generation.cancelled")
+    end
+
+    # === content_stats tests ===
+
+    test "content_stats returns hash with cities and totals" do
+      stats = Ai::ContentOrchestrator.content_stats
+
+      assert stats.is_a?(Hash)
+      assert_includes stats.keys, :cities
+      assert_includes stats.keys, :totals
+      assert stats[:cities].is_a?(Array)
+      assert stats[:totals].is_a?(Hash)
+    end
+
+    test "content_stats totals include expected keys" do
+      stats = Ai::ContentOrchestrator.content_stats
+
+      assert_includes stats[:totals].keys, :locations
+      assert_includes stats[:totals].keys, :experiences
+      assert_includes stats[:totals].keys, :plans
+      assert_includes stats[:totals].keys, :ai_plans
+      assert_includes stats[:totals].keys, :audio
+    end
+
+    # === Error classes tests ===
+
+    test "GenerationError is a subclass of StandardError" do
+      assert Ai::ContentOrchestrator::GenerationError < StandardError
+    end
+
+    test "CancellationError is a subclass of StandardError" do
+      assert Ai::ContentOrchestrator::CancellationError < StandardError
+    end
+  end
+end

--- a/test/services/ai/experience_analyzer_test.rb
+++ b/test/services/ai/experience_analyzer_test.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Ai
+  class ExperienceAnalyzerTest < ActiveSupport::TestCase
+    setup do
+      @analyzer = Ai::ExperienceAnalyzer.new
+    end
+
+    # === generate_report limit parameter tests ===
+
+    test "generate_report accepts limit parameter" do
+      assert_nothing_raised do
+        @analyzer.generate_report(limit: 10)
+      end
+    end
+
+    test "generate_report with limit nil returns all results" do
+      report = @analyzer.generate_report(limit: nil)
+
+      # With nil limit, should return all experiences needing rebuild
+      assert report[:worst_experiences].is_a?(Array)
+    end
+
+    test "generate_report with limit restricts worst_experiences count" do
+      report = @analyzer.generate_report(limit: 5)
+
+      assert report[:worst_experiences].length <= 5
+    end
+
+    test "generate_report with limit restricts deletable_experiences count" do
+      report = @analyzer.generate_report(limit: 5)
+
+      assert report[:deletable_experiences].length <= 5
+    end
+
+    test "generate_report with limit restricts similar_experiences count" do
+      report = @analyzer.generate_report(limit: 10)
+
+      # similar_experiences uses limit / 2
+      assert report[:similar_experiences].length <= 5
+    end
+
+    test "generate_report default limit is 20" do
+      report = @analyzer.generate_report
+
+      assert report[:worst_experiences].length <= 20
+      assert report[:deletable_experiences].length <= 20
+      assert report[:similar_experiences].length <= 10
+    end
+
+    # === Report structure tests ===
+
+    test "generate_report returns expected keys" do
+      report = @analyzer.generate_report
+
+      assert_includes report.keys, :total_experiences
+      assert_includes report.keys, :experiences_with_issues
+      assert_includes report.keys, :experiences_needing_rebuild
+      assert_includes report.keys, :experiences_to_delete
+      assert_includes report.keys, :similar_experience_pairs
+      assert_includes report.keys, :issues_by_severity
+      assert_includes report.keys, :issues_by_type
+      assert_includes report.keys, :worst_experiences
+      assert_includes report.keys, :deletable_experiences
+      assert_includes report.keys, :similar_experiences
+    end
+
+    # === Score threshold tests ===
+
+    test "DELETE_THRESHOLD_SCORE is defined" do
+      assert_equal 20, Ai::ExperienceAnalyzer::DELETE_THRESHOLD_SCORE
+    end
+
+    test "SIMILARITY_THRESHOLD is defined" do
+      assert_equal 0.7, Ai::ExperienceAnalyzer::SIMILARITY_THRESHOLD
+    end
+  end
+end

--- a/test/services/ai/plan_analyzer_integration_test.rb
+++ b/test/services/ai/plan_analyzer_integration_test.rb
@@ -1,0 +1,180 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Ai
+  class PlanAnalyzerIntegrationTest < ActiveSupport::TestCase
+    setup do
+      @analyzer = Ai::PlanAnalyzer.new
+      @city = "Sarajevo"
+
+      # Create experience for plans
+      @experience = Experience.create!(title: "Test Experience")
+    end
+
+    # === Unlimited limit tests ===
+
+    test "generate_report with limit: nil returns all plans without truncation" do
+      # Create 25 AI-generated plans with issues (more than default limit of 20)
+      plans = []
+      25.times do |i|
+        plan = Plan.create!(
+          title: "Test Plan #{i}",
+          city_name: @city,
+          user_id: nil
+        )
+        # Add an experience so it won't be marked for deletion
+        plan.plan_experiences.create!(experience: @experience, day_number: 1, position: 1)
+        plans << plan
+      end
+
+      # Generate report with unlimited (nil) limit
+      report = @analyzer.generate_report(limit: nil)
+
+      # Should return all 25 plans, not truncated to 20
+      assert_equal 25, report[:worst_plans].length + report[:deletable_plans].length,
+                   "With nil limit, should return all plans needing action"
+    end
+
+    test "generate_report with limit: 20 (default) truncates results" do
+      # Create 25 AI-generated plans with issues
+      plans = []
+      25.times do |i|
+        plan = Plan.create!(
+          title: "Short", # Short title = quality issue
+          city_name: @city,
+          user_id: nil
+        )
+        plan.plan_experiences.create!(experience: @experience, day_number: 1, position: 1)
+        plans << plan
+      end
+
+      # Generate report with default limit
+      report = @analyzer.generate_report
+
+      # Should truncate to 20
+      assert report[:worst_plans].length <= 20, "Default limit should cap worst_plans at 20"
+      assert report[:deletable_plans].length <= 20, "Default limit should cap deletable_plans at 20"
+    end
+
+    test "generate_report similar_plans uses limit / 2" do
+      # Create many similar plan pairs
+      # First, create base plans
+      15.times do |i|
+        # Create two similar plans (same city, same profile)
+        plan1 = Plan.create!(
+          title: "Family Sarajevo Tour Part 1",
+          city_name: @city,
+          user_id: nil,
+          preferences: { "tourist_profile" => "family" }
+        )
+        plan1.plan_experiences.create!(experience: @experience, day_number: 1, position: 1)
+
+        plan2 = Plan.create!(
+          title: "Family Sarajevo Tour Part 2",
+          city_name: @city,
+          user_id: nil,
+          preferences: { "tourist_profile" => "family" }
+        )
+        plan2.plan_experiences.create!(experience: @experience, day_number: 1, position: 1)
+      end
+
+      # With limit: 20, similar_plans should be capped at 10 (20/2)
+      report = @analyzer.generate_report(limit: 20)
+      assert report[:similar_plans].length <= 10, "Similar plans should be limited to limit/2"
+
+      # With nil limit, all similar plans should be returned
+      report_unlimited = @analyzer.generate_report(limit: nil)
+      # Note: exact count depends on similarity calculation
+      assert report_unlimited[:similar_plans].length >= report[:similar_plans].length,
+             "Unlimited should return at least as many similar plans as limited"
+    end
+
+    test "generate_report with custom limit respects that limit" do
+      # Create 15 AI-generated plans
+      15.times do |i|
+        plan = Plan.create!(
+          title: "Test Plan #{i}",
+          city_name: @city,
+          user_id: nil
+        )
+        plan.plan_experiences.create!(experience: @experience, day_number: 1, position: 1)
+      end
+
+      # Use small limit
+      report = @analyzer.generate_report(limit: 5)
+
+      assert report[:worst_plans].length <= 5, "Should respect custom limit for worst_plans"
+      assert report[:deletable_plans].length <= 5, "Should respect custom limit for deletable_plans"
+      assert report[:similar_plans].length <= 2, "Similar plans should be limit/2 = 2"
+    end
+
+    # === Score calculation tests ===
+
+    test "plans with critical issues have score <= 70" do
+      # Create plan with critical issues (no experiences)
+      plan = Plan.create!(
+        title: "Test Plan",
+        city_name: @city,
+        user_id: nil
+      )
+      # Don't add experiences - this is a critical issue
+
+      result = @analyzer.analyze(plan)
+
+      assert result[:score] <= 70, "Critical issue (no experiences) should reduce score significantly"
+      assert result[:issues].any? { |i| i[:severity] == :critical }, "Should have critical issues"
+    end
+
+    test "plans with ekavica have high severity issues" do
+      plan = Plan.create!(
+        title: "Lepo mesto za posetu", # Ekavica words
+        city_name: @city,
+        user_id: nil
+      )
+      plan.plan_experiences.create!(experience: @experience, day_number: 1, position: 1)
+
+      # Set Bosnian title translation with ekavica
+      plan.set_translation(:title, "Lepo mesto za posetu", :bs)
+      plan.save!
+
+      result = @analyzer.analyze(plan)
+
+      ekavica_issues = result[:issues].select { |i| i[:type] == :ekavica_violation }
+      assert ekavica_issues.any?, "Should detect ekavica violations"
+      assert ekavica_issues.first[:severity] == :high, "Ekavica should be high severity"
+    end
+
+    test "user-owned plans are skipped" do
+      user = User.create!(username: "testuser", password: "password123")
+
+      plan = Plan.create!(
+        title: "User Plan",
+        city_name: @city,
+        user: user
+      )
+
+      result = @analyzer.analyze(plan)
+
+      assert result[:skipped], "User-owned plan should be skipped"
+      assert_equal "User-owned plan", result[:skip_reason]
+      assert_equal 100, result[:score], "Skipped plans should have score 100"
+    end
+
+    test "plans with score <= 20 should be marked for deletion" do
+      # Create plan with many issues to get very low score
+      plan = Plan.create!(
+        title: "X", # Too short
+        city_name: @city,
+        user_id: nil
+      )
+      # No experiences = critical issue
+      # No translations = more issues
+
+      result = @analyzer.analyze(plan)
+
+      assert result[:should_delete], "Very low score plan should be marked for deletion"
+      assert result[:delete_reason].present?, "Should have delete reason"
+    end
+  end
+end

--- a/test/services/ai/plan_analyzer_test.rb
+++ b/test/services/ai/plan_analyzer_test.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Ai
+  class PlanAnalyzerTest < ActiveSupport::TestCase
+    setup do
+      @analyzer = Ai::PlanAnalyzer.new
+    end
+
+    # === generate_report limit parameter tests ===
+
+    test "generate_report accepts limit parameter" do
+      assert_nothing_raised do
+        @analyzer.generate_report(limit: 10)
+      end
+    end
+
+    test "generate_report with limit nil returns all results" do
+      report = @analyzer.generate_report(limit: nil)
+
+      # With nil limit, should return all plans needing rebuild
+      assert report[:worst_plans].is_a?(Array)
+    end
+
+    test "generate_report with limit restricts worst_plans count" do
+      report = @analyzer.generate_report(limit: 5)
+
+      assert report[:worst_plans].length <= 5
+    end
+
+    test "generate_report with limit restricts deletable_plans count" do
+      report = @analyzer.generate_report(limit: 5)
+
+      assert report[:deletable_plans].length <= 5
+    end
+
+    test "generate_report with limit restricts similar_plans count" do
+      report = @analyzer.generate_report(limit: 10)
+
+      # similar_plans uses limit / 2
+      assert report[:similar_plans].length <= 5
+    end
+
+    test "generate_report default limit is 20" do
+      report = @analyzer.generate_report
+
+      assert report[:worst_plans].length <= 20
+      assert report[:deletable_plans].length <= 20
+      assert report[:similar_plans].length <= 10
+    end
+
+    # === Report structure tests ===
+
+    test "generate_report returns expected keys" do
+      report = @analyzer.generate_report
+
+      assert_includes report.keys, :total_plans
+      assert_includes report.keys, :plans_with_issues
+      assert_includes report.keys, :plans_needing_rebuild
+      assert_includes report.keys, :plans_to_delete
+      assert_includes report.keys, :similar_plan_pairs
+      assert_includes report.keys, :issues_by_severity
+      assert_includes report.keys, :issues_by_type
+      assert_includes report.keys, :worst_plans
+      assert_includes report.keys, :deletable_plans
+      assert_includes report.keys, :similar_plans
+    end
+
+    # === Score threshold tests ===
+
+    test "DELETE_THRESHOLD_SCORE is defined" do
+      assert_equal 20, Ai::PlanAnalyzer::DELETE_THRESHOLD_SCORE
+    end
+
+    test "SIMILARITY_THRESHOLD is defined" do
+      assert_equal 0.7, Ai::PlanAnalyzer::SIMILARITY_THRESHOLD
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,7 @@
 ENV["RAILS_ENV"] ||= "test"
 require_relative "../config/environment"
 require "rails/test_help"
+require "minitest/mock"
 
 module ActiveSupport
   class TestCase


### PR DESCRIPTION
## Plan Rebuild Experience Replacement
- Add EXPERIENCE_REBUILD_THRESHOLD (50) - plans with score < 50 get new experiences
- AI decides which experiences to replace based on tourist profile fit
- Preserve day_number and position when replacing experiences
- Only process AI-generated plans (skip user-owned plans)

## Content Generation Limits
- Add max_locations parameter (default: 100)
- Add max_plans parameter (default: 50)
- Update max_experiences with better options
- All limits: 0 = unlimited, nil = use default

## Admin UI Updates
- Add all three limit selectors (locations, experiences, plans)
- Add skip checkboxes (locations, experiences, plans)
- Add analyze_descriptions option to Fix Location Cities
- Add accommodations mode to Rebuild Experiences

## Test Fixes
- Fix OpenaiQueue tests to use proper mocking pattern
- Fix OpenaiRequestJob retry tests for ActiveJob behavior
- Add comprehensive tests for new functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)