### PR TITLE
Fix location generation and filter soup kitchens

### DIFF
--- a/app/services/geoapify_service.rb
+++ b/app/services/geoapify_service.rb
@@ -8,9 +8,12 @@ class GeoapifyService
   PLACE_DETAILS_URL = "https://api.geoapify.com/v2/place-details".freeze
 
   # Categories to EXCLUDE from search results
-  # Includes retirement homes and social facilities not relevant for tourism
+  # Includes retirement homes, social facilities, and soup kitchens not relevant for tourism
   EXCLUDED_CATEGORIES = %w[
     service.social_facility
+    service.social_facility.food_bank
+    service.social_facility.soup_kitchen
+    amenity.social_facility
     healthcare.nursing_home
     healthcare.assisted_living
     healthcare.retirement_home
@@ -30,6 +33,19 @@ class GeoapifyService
     elderly
     seniorski
     aged care
+    soup kitchen
+    narodna kuhinja
+    pučka kuhinja
+    javna kuhinja
+    socijalna kuhinja
+    food bank
+    banka hrane
+    humanitarna pomoć
+    humanitarna pomoc
+    besplatna hrana
+    socijalni centar
+    centar za socijalnu pomoć
+    centar za socijalnu pomoc
   ].freeze
 
   # Default tourism categories (fallback if database is empty)


### PR DESCRIPTION
This commit adds several improvements to location generation and fix jobs:

1. Soup Kitchen Exclusions:
   - Added soup kitchen keywords and categories to GeoapifyService exclusions
   - Added soup_kitchen? detection method to LocationCityFixJob
   - Added soup_kitchen_suggestion? check to CountryWideLocationGenerator
   - Updated AI prompts to explicitly exclude soup kitchens
   - Keywords include both English and Bosnian/Croatian variants

2. City-Coordinate Mismatch Detection:
   - Added check_name_city_mismatch to detect when a location name mentions a city different from its actual coordinates (e.g., "Restaurant in Blagaj" with coordinates in Mostar)
   - Added BIH_CITIES constant with known cities for validation
   - Locations with mismatched city names are now rejected during generation and can be removed by LocationCityFixJob

3. LocationCityFixJob Enhancements:
   - Added remove_soup_kitchens parameter (default: true)
   - Added remove_city_mismatches parameter (default: true)
   - Both soup kitchens and mismatched locations are now removed during job run
   - Added tracking and reporting for removed locations

4. Tests:
   - Added tests for soup kitchen keyword constants
   - Added tests for soup_kitchen? detection
   - Added tests for city mismatch detection
   - Added tests for cities_different? method