### PR TITLE
Add job to fetch images from Wikimedia Commons

### DIFF
--- a/app/jobs/wikimedia_image_fetch_job.rb
+++ b/app/jobs/wikimedia_image_fetch_job.rb
@@ -1,0 +1,299 @@
+# frozen_string_literal: true
+
+# Background job for fetching images from Wikimedia Commons for locations without photos.
+# Selects random locations that have no attached photos and searches Wikimedia Commons
+# for relevant images based on location name and city.
+#
+# Usage:
+#   WikimediaImageFetchJob.perform_later
+#   WikimediaImageFetchJob.perform_later(dry_run: true) # Preview mode - don't attach images
+#   WikimediaImageFetchJob.perform_later(max_locations: 5) # Process up to 5 locations
+#   WikimediaImageFetchJob.perform_later(images_per_location: 3) # Fetch 3 images per location
+#   WikimediaImageFetchJob.perform_later(use_coordinates: true) # Also search by GPS coordinates
+#
+class WikimediaImageFetchJob < ApplicationJob
+  queue_as :default
+
+  # Retry on transient failures
+  retry_on StandardError, wait: :polynomially_longer, attempts: 3
+
+  # Discard on permanent failures
+  discard_on WikimediaService::ApiError
+
+  # Default settings
+  DEFAULT_MAX_LOCATIONS = 10
+  DEFAULT_IMAGES_PER_LOCATION = 5
+  MAX_IMAGES_PER_LOCATION = 10
+
+  def perform(dry_run: false, max_locations: nil, images_per_location: nil, use_coordinates: true)
+    max_locations ||= DEFAULT_MAX_LOCATIONS
+    images_per_location ||= DEFAULT_IMAGES_PER_LOCATION
+    images_per_location = [images_per_location, MAX_IMAGES_PER_LOCATION].min
+
+    Rails.logger.info "[WikimediaImageFetchJob] Starting (dry_run: #{dry_run}, max_locations: #{max_locations}, images_per_location: #{images_per_location})"
+
+    save_status("in_progress", "Starting Wikimedia image fetch...")
+
+    results = {
+      started_at: Time.current,
+      dry_run: dry_run,
+      total_locations_checked: 0,
+      locations_processed: 0,
+      images_found: 0,
+      images_attached: 0,
+      errors: [],
+      location_results: []
+    }
+
+    begin
+      service = WikimediaService.new
+
+      # Find locations without photos
+      locations_without_photos = find_locations_without_photos(max_locations)
+
+      if locations_without_photos.empty?
+        results[:status] = "completed"
+        results[:finished_at] = Time.current
+        save_status("completed", "No locations without photos found", results: results)
+        return results
+      end
+
+      results[:total_locations_checked] = locations_without_photos.count
+
+      locations_without_photos.each_with_index do |location, index|
+        begin
+          save_status("in_progress", "Processing #{index + 1}/#{locations_without_photos.count}: #{location.name}")
+
+          location_result = process_location(location, service,
+            dry_run: dry_run,
+            images_per_location: images_per_location,
+            use_coordinates: use_coordinates
+          )
+
+          results[:location_results] << location_result
+          results[:locations_processed] += 1
+          results[:images_found] += location_result[:images_found]
+          results[:images_attached] += location_result[:images_attached]
+
+        rescue StandardError => e
+          error_info = {
+            location_id: location.id,
+            name: location.name,
+            error: e.message
+          }
+          results[:errors] << error_info
+          Rails.logger.warn "[WikimediaImageFetchJob] Error processing #{location.name}: #{e.message}"
+        end
+      end
+
+      results[:status] = "completed"
+      results[:finished_at] = Time.current
+
+      summary = build_completion_summary(results)
+      save_status("completed", summary, results: results)
+
+      Rails.logger.info "[WikimediaImageFetchJob] Completed: #{summary}"
+      results
+
+    rescue StandardError => e
+      results[:status] = "failed"
+      results[:error] = e.message
+      results[:finished_at] = Time.current
+      save_status("failed", e.message, results: results)
+      Rails.logger.error "[WikimediaImageFetchJob] Failed: #{e.message}"
+      raise
+    end
+  end
+
+  # Returns current status of the job
+  def self.current_status
+    {
+      status: Setting.get("wikimedia_fetch.status", default: "idle"),
+      message: Setting.get("wikimedia_fetch.message", default: nil),
+      results: JSON.parse(Setting.get("wikimedia_fetch.results", default: "{}") || "{}")
+    }
+  rescue JSON::ParserError
+    { status: "idle", message: nil, results: {} }
+  end
+
+  # Clear any existing status
+  def self.clear_status!
+    Setting.set("wikimedia_fetch.status", "idle")
+    Setting.set("wikimedia_fetch.message", nil)
+    Setting.set("wikimedia_fetch.results", "{}")
+  end
+
+  # Force reset a stuck job
+  def self.force_reset!
+    Setting.set("wikimedia_fetch.status", "idle")
+    Setting.set("wikimedia_fetch.message", "Force reset by admin")
+  end
+
+  private
+
+  # Find locations without any attached photos
+  # Selects random locations to distribute image fetching
+  def find_locations_without_photos(limit)
+    # Get location IDs that have photos
+    locations_with_photos_ids = ActiveStorage::Attachment
+      .where(record_type: "Location", name: "photos")
+      .distinct
+      .pluck(:record_id)
+
+    # Find locations without photos, preferring those with coordinates
+    Location
+      .where.not(id: locations_with_photos_ids)
+      .with_coordinates
+      .order(Arel.sql("RANDOM()"))
+      .limit(limit)
+  end
+
+  # Process a single location - search for images and optionally attach them
+  def process_location(location, service, dry_run:, images_per_location:, use_coordinates:)
+    result = {
+      location_id: location.id,
+      name: location.name,
+      city: location.city,
+      images_found: 0,
+      images_attached: 0,
+      images: []
+    }
+
+    # Build search query
+    search_query = build_search_query(location)
+    Rails.logger.info "[WikimediaImageFetchJob] Searching for: #{search_query}"
+
+    # Search by text query
+    images = service.search_images(search_query, limit: images_per_location)
+
+    # Also search by coordinates if enabled and location has them
+    if use_coordinates && location.geocoded? && images.length < images_per_location
+      Rails.logger.info "[WikimediaImageFetchJob] Also searching by coordinates: #{location.lat}, #{location.lng}"
+      coord_images = service.search_by_coordinates(
+        location.lat,
+        location.lng,
+        radius: 500,
+        limit: images_per_location - images.length
+      )
+
+      # Merge results, avoiding duplicates by URL
+      existing_urls = images.map { |i| i[:url] }
+      coord_images.each do |img|
+        images << img unless existing_urls.include?(img[:url])
+      end
+    end
+
+    result[:images_found] = images.length
+
+    if images.empty?
+      Rails.logger.info "[WikimediaImageFetchJob] No images found for #{location.name}"
+      return result
+    end
+
+    # Process each found image
+    images.each do |image|
+      image_result = {
+        title: image[:title],
+        url: image[:url],
+        thumb_url: image[:thumb_url],
+        description: image[:description],
+        license: image[:license],
+        author: image[:author],
+        width: image[:width],
+        height: image[:height],
+        page_url: image[:page_url],
+        attached: false
+      }
+
+      unless dry_run
+        # Download and attach image
+        if attach_image_to_location(location, image, service)
+          image_result[:attached] = true
+          result[:images_attached] += 1
+        end
+      end
+
+      result[:images] << image_result
+    end
+
+    result
+  end
+
+  # Build search query from location data
+  def build_search_query(location)
+    parts = []
+
+    # Primary: location name
+    parts << location.name if location.name.present?
+
+    # Add city for context
+    parts << location.city if location.city.present?
+
+    # Join with space
+    parts.join(" ")
+  end
+
+  # Download and attach image to location
+  def attach_image_to_location(location, image, service)
+    return false unless image[:url].present?
+
+    Rails.logger.info "[WikimediaImageFetchJob] Downloading: #{image[:url]}"
+
+    io = service.download_image(image[:url])
+    return false unless io
+
+    # Determine filename
+    filename = File.basename(URI.parse(image[:url]).path)
+    filename = "wikimedia_#{SecureRandom.hex(4)}.jpg" if filename.blank?
+
+    # Determine content type
+    content_type = image[:mime] || "image/jpeg"
+
+    # Attach to location
+    location.photos.attach(
+      io: io,
+      filename: filename,
+      content_type: content_type
+    )
+
+    Rails.logger.info "[WikimediaImageFetchJob] Attached #{filename} to #{location.name}"
+    true
+
+  rescue StandardError => e
+    Rails.logger.warn "[WikimediaImageFetchJob] Failed to attach image: #{e.message}"
+    false
+  ensure
+    io&.close if io.respond_to?(:close)
+  end
+
+  def build_completion_summary(results)
+    parts = []
+
+    if results[:dry_run]
+      parts << "Preview completed:"
+    else
+      parts << "Completed:"
+    end
+
+    parts << "#{results[:locations_processed]} locations processed"
+    parts << "#{results[:images_found]} images found"
+
+    unless results[:dry_run]
+      parts << "#{results[:images_attached]} images attached"
+    end
+
+    if results[:errors].any?
+      parts << "#{results[:errors].count} errors"
+    end
+
+    parts.join(", ")
+  end
+
+  def save_status(status, message, results: nil)
+    Setting.set("wikimedia_fetch.status", status)
+    Setting.set("wikimedia_fetch.message", message)
+    Setting.set("wikimedia_fetch.results", results.to_json) if results
+  rescue StandardError => e
+    Rails.logger.warn "[WikimediaImageFetchJob] Could not save status: #{e.message}"
+  end
+end

--- a/app/services/wikimedia_service.rb
+++ b/app/services/wikimedia_service.rb
@@ -1,0 +1,283 @@
+# frozen_string_literal: true
+
+# Service for fetching images from Wikimedia Commons API
+# Uses the MediaWiki API to search for images related to locations in Bosnia & Herzegovina
+#
+# Documentation: https://www.mediawiki.org/wiki/API:Main_page
+# Commons API: https://commons.wikimedia.org/w/api.php
+#
+# Example usage:
+#   service = WikimediaService.new
+#   results = service.search_images("Stari Most Mostar")
+#   # => [{ title: "File:...", url: "https://...", thumb_url: "https://...", description: "..." }, ...]
+#
+class WikimediaService
+  class Error < StandardError; end
+  class RateLimitError < Error; end
+  class ApiError < Error; end
+
+  # Wikimedia Commons API endpoint
+  API_ENDPOINT = "https://commons.wikimedia.org/w/api.php"
+
+  # Rate limiting: Wikimedia requests max 200 requests/minute for unauthenticated
+  # We'll be conservative with 1 request per second
+  RATE_LIMIT_SLEEP = 1.0
+
+  # Default search parameters
+  DEFAULT_LIMIT = 10
+  MAX_LIMIT = 50
+
+  # Preferred image extensions (prioritize these)
+  PREFERRED_EXTENSIONS = %w[.jpg .jpeg .png .webp].freeze
+
+  # Minimum image dimensions (skip tiny images)
+  MIN_WIDTH = 400
+  MIN_HEIGHT = 300
+
+  def initialize
+    @last_request_time = nil
+  end
+
+  # Search for images related to a location
+  # @param query [String] Search query (location name, city, etc.)
+  # @param limit [Integer] Maximum number of results (default: 10, max: 50)
+  # @return [Array<Hash>] Array of image results with :title, :url, :thumb_url, :description, :width, :height
+  def search_images(query, limit: DEFAULT_LIMIT)
+    limit = [limit, MAX_LIMIT].min
+
+    # First, search for files matching the query
+    search_results = search_files(query, limit: limit * 2) # Get more to filter later
+    return [] if search_results.empty?
+
+    # Get detailed info for each file
+    images = []
+    search_results.each do |result|
+      break if images.length >= limit
+
+      image_info = get_image_info(result[:title])
+      next unless image_info && valid_image?(image_info)
+
+      images << image_info
+    end
+
+    images
+  end
+
+  # Search for images by geographic coordinates (geosearch)
+  # @param lat [Float] Latitude
+  # @param lng [Float] Longitude
+  # @param radius [Integer] Search radius in meters (default: 1000, max: 10000)
+  # @param limit [Integer] Maximum number of results
+  # @return [Array<Hash>] Array of image results
+  def search_by_coordinates(lat, lng, radius: 1000, limit: DEFAULT_LIMIT)
+    return [] if lat.blank? || lng.blank?
+
+    limit = [limit, MAX_LIMIT].min
+    radius = [radius, 10_000].min
+
+    rate_limit!
+
+    params = {
+      action: "query",
+      format: "json",
+      generator: "geosearch",
+      ggscoord: "#{lat}|#{lng}",
+      ggsradius: radius,
+      ggslimit: limit * 2,
+      ggsnamespace: 6, # File namespace
+      prop: "imageinfo",
+      iiprop: "url|size|extmetadata",
+      iiurlwidth: 800 # Get thumbnail URL
+    }
+
+    response = make_request(params)
+    pages = response.dig("query", "pages") || {}
+
+    images = []
+    pages.each_value do |page|
+      next unless page["imageinfo"]&.any?
+
+      image_info = parse_image_info(page)
+      next unless image_info && valid_image?(image_info)
+
+      images << image_info
+      break if images.length >= limit
+    end
+
+    images
+  end
+
+  # Get detailed information about a specific image
+  # @param title [String] Image title (including "File:" prefix)
+  # @return [Hash, nil] Image info or nil if not found
+  def get_image_info(title)
+    rate_limit!
+
+    params = {
+      action: "query",
+      format: "json",
+      titles: title,
+      prop: "imageinfo",
+      iiprop: "url|size|extmetadata|mime",
+      iiurlwidth: 1200 # Larger thumbnail for preview
+    }
+
+    response = make_request(params)
+    pages = response.dig("query", "pages") || {}
+
+    page = pages.values.first
+    return nil unless page && page["imageinfo"]&.any?
+
+    parse_image_info(page)
+  end
+
+  # Download image from URL and return IO object
+  # @param url [String] Image URL
+  # @param timeout [Integer] Download timeout in seconds
+  # @return [IO, nil] IO object with image data or nil on failure
+  def download_image(url, timeout: 30)
+    return nil if url.blank?
+
+    URI.parse(url).open(
+      read_timeout: timeout,
+      open_timeout: 10,
+      "User-Agent" => user_agent
+    )
+  rescue OpenURI::HTTPError, SocketError, Timeout::Error => e
+    Rails.logger.warn "[WikimediaService] Failed to download image from #{url}: #{e.message}"
+    nil
+  end
+
+  private
+
+  # Search for files using the search API
+  def search_files(query, limit:)
+    rate_limit!
+
+    # Add Bosnia/Herzegovina context to improve relevance
+    enhanced_query = "#{query} Bosnia Herzegovina"
+
+    params = {
+      action: "query",
+      format: "json",
+      list: "search",
+      srsearch: enhanced_query,
+      srnamespace: 6, # File namespace only
+      srlimit: limit,
+      srprop: "snippet|titlesnippet"
+    }
+
+    response = make_request(params)
+    search_results = response.dig("query", "search") || []
+
+    search_results.map do |result|
+      {
+        title: result["title"],
+        snippet: result["snippet"]
+      }
+    end
+  end
+
+  # Parse image info from API response page
+  def parse_image_info(page)
+    info = page["imageinfo"]&.first
+    return nil unless info
+
+    metadata = info["extmetadata"] || {}
+
+    {
+      title: page["title"],
+      url: info["url"],
+      thumb_url: info["thumburl"] || info["url"],
+      description: extract_description(metadata),
+      license: extract_license(metadata),
+      author: extract_author(metadata),
+      width: info["width"],
+      height: info["height"],
+      mime: info["mime"],
+      page_url: "https://commons.wikimedia.org/wiki/#{CGI.escape(page['title'].to_s.tr(' ', '_'))}"
+    }
+  end
+
+  # Extract description from metadata
+  def extract_description(metadata)
+    desc = metadata.dig("ImageDescription", "value")
+    return nil if desc.blank?
+
+    # Strip HTML tags
+    ActionController::Base.helpers.strip_tags(desc).truncate(500)
+  end
+
+  # Extract license info from metadata
+  def extract_license(metadata)
+    metadata.dig("LicenseShortName", "value") ||
+      metadata.dig("License", "value") ||
+      "Unknown"
+  end
+
+  # Extract author from metadata
+  def extract_author(metadata)
+    author = metadata.dig("Artist", "value")
+    return nil if author.blank?
+
+    ActionController::Base.helpers.strip_tags(author).truncate(200)
+  end
+
+  # Check if image meets quality requirements
+  def valid_image?(image)
+    return false unless image[:url].present?
+    return false unless image[:width].to_i >= MIN_WIDTH
+    return false unless image[:height].to_i >= MIN_HEIGHT
+
+    # Check for preferred extensions
+    extension = File.extname(image[:url]).downcase
+    return false unless PREFERRED_EXTENSIONS.include?(extension) || image[:mime]&.start_with?("image/")
+
+    # Skip SVG and other non-photo formats
+    return false if image[:mime] == "image/svg+xml"
+
+    true
+  end
+
+  # Make HTTP request to API
+  def make_request(params)
+    uri = URI(API_ENDPOINT)
+    uri.query = URI.encode_www_form(params)
+
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true
+    http.open_timeout = 10
+    http.read_timeout = 30
+
+    request = Net::HTTP::Get.new(uri)
+    request["User-Agent"] = user_agent
+
+    response = http.request(request)
+
+    unless response.is_a?(Net::HTTPSuccess)
+      raise ApiError, "Wikimedia API returned #{response.code}: #{response.body}"
+    end
+
+    JSON.parse(response.body)
+  rescue JSON::ParserError => e
+    raise ApiError, "Failed to parse Wikimedia API response: #{e.message}"
+  rescue Net::OpenTimeout, Net::ReadTimeout => e
+    raise ApiError, "Wikimedia API timeout: #{e.message}"
+  end
+
+  # Enforce rate limiting
+  def rate_limit!
+    if @last_request_time
+      elapsed = Time.current - @last_request_time
+      if elapsed < RATE_LIMIT_SLEEP
+        sleep(RATE_LIMIT_SLEEP - elapsed)
+      end
+    end
+    @last_request_time = Time.current
+  end
+
+  # User agent for API requests (required by Wikimedia)
+  def user_agent
+    "UsputBaBot/1.0 (https://usput.ba; contact@usput.ba) Ruby/#{RUBY_VERSION}"
+  end
+end

--- a/app/views/admin/ai/_wikimedia_images_status.html.erb
+++ b/app/views/admin/ai/_wikimedia_images_status.html.erb
@@ -1,0 +1,120 @@
+<% if status[:status] == "in_progress" %>
+  <div class="bg-blue-50 border border-blue-200 rounded-lg p-4">
+    <div class="flex items-center justify-between gap-3">
+      <div class="flex items-center gap-3">
+        <svg class="animate-spin h-5 w-5 text-blue-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+          <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+        </svg>
+        <div>
+          <span class="font-medium text-blue-900">Wikimedia image fetch in progress</span>
+          <span class="text-blue-700 ml-2"><%= status[:message] %></span>
+        </div>
+      </div>
+      <%= form_with url: admin_force_reset_wikimedia_fetch_admin_ai_path, method: :post, class: "inline", data: { turbo_confirm: "Are you sure? This will reset the fetch status and allow you to start a new run.", controller: "credential-form", "credential-form-username-id-value": "ai_admin_username", "credential-form-password-id-value": "ai_admin_password" } do |f| %>
+        <%= f.hidden_field :admin_username, data: { "credential-form-target": "usernameField" } %>
+        <%= f.hidden_field :admin_password, data: { "credential-form-target": "passwordField" } %>
+        <button type="submit"
+                class="inline-flex items-center gap-1 px-3 py-1.5 bg-red-600 text-white text-sm font-medium rounded hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 transition-colors"
+                data-action="credential-form#copyCredentials">
+          Force Stop & Restart
+        </button>
+      <% end %>
+    </div>
+  </div>
+<% elsif status[:status] == "completed" && status[:results].present? %>
+  <div class="bg-green-50 border border-green-200 rounded-lg p-4">
+    <div class="flex items-start gap-3">
+      <svg class="h-5 w-5 text-green-600 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
+      </svg>
+      <div class="flex-1">
+        <span class="font-medium text-green-900">
+          <%= status[:results]["dry_run"] ? "Preview completed" : "Wikimedia image fetch completed" %>
+        </span>
+        <p class="text-green-700 text-sm mt-1"><%= status[:message] %></p>
+
+        <% if status[:results]["location_results"].present? && status[:results]["location_results"].any? %>
+          <details class="mt-3">
+            <summary class="text-sm text-green-700 cursor-pointer hover:underline font-medium">
+              View <%= status[:results]["location_results"].size %> location results
+              (<%= status[:results]["images_found"] %> images found<%= status[:results]["dry_run"] ? "" : ", #{status[:results]["images_attached"]} attached" %>)
+            </summary>
+            <div class="mt-3 space-y-4 max-h-96 overflow-y-auto">
+              <% status[:results]["location_results"].each do |loc_result| %>
+                <div class="bg-white rounded-lg p-3 border border-green-100">
+                  <div class="flex items-center justify-between mb-2">
+                    <h4 class="font-medium text-gray-900">
+                      <%= loc_result["name"] %>
+                      <span class="text-xs text-gray-500 font-normal">(<%= loc_result["city"] %>)</span>
+                    </h4>
+                    <span class="text-xs px-2 py-1 rounded-full <%= loc_result["images_found"].to_i > 0 ? 'bg-green-100 text-green-800' : 'bg-gray-100 text-gray-600' %>">
+                      <%= loc_result["images_found"] %> found
+                      <% unless status[:results]["dry_run"] %>
+                        / <%= loc_result["images_attached"] %> attached
+                      <% end %>
+                    </span>
+                  </div>
+
+                  <% if loc_result["images"].present? && loc_result["images"].any? %>
+                    <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-2 mt-2">
+                      <% loc_result["images"].first(10).each do |image| %>
+                        <div class="relative group">
+                          <a href="<%= image["page_url"] %>" target="_blank" rel="noopener noreferrer" class="block">
+                            <img src="<%= image["thumb_url"] %>"
+                                 alt="<%= image["title"] %>"
+                                 class="w-full h-20 object-cover rounded border border-gray-200 hover:border-green-400 transition-colors"
+                                 loading="lazy">
+                          </a>
+                          <div class="absolute bottom-0 left-0 right-0 bg-black bg-opacity-60 text-white text-xs p-1 rounded-b opacity-0 group-hover:opacity-100 transition-opacity truncate">
+                            <%= image["license"] || "Unknown license" %>
+                          </div>
+                          <% if image["attached"] %>
+                            <div class="absolute top-1 right-1 bg-green-500 text-white rounded-full p-0.5">
+                              <svg class="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M5 13l4 4L19 7"></path>
+                              </svg>
+                            </div>
+                          <% end %>
+                        </div>
+                      <% end %>
+                    </div>
+                  <% else %>
+                    <p class="text-xs text-gray-500 italic">No images found for this location</p>
+                  <% end %>
+                </div>
+              <% end %>
+            </div>
+          </details>
+        <% end %>
+
+        <% if status[:results]["errors"].present? && status[:results]["errors"].any? %>
+          <details class="mt-2">
+            <summary class="text-sm text-red-600 cursor-pointer hover:underline">
+              View <%= status[:results]["errors"].size %> errors
+            </summary>
+            <ul class="mt-2 text-xs text-red-700 space-y-1 max-h-40 overflow-y-auto">
+              <% status[:results]["errors"].each do |error| %>
+                <li class="bg-red-50 rounded px-2 py-1">
+                  <strong><%= error["name"] %></strong>: <%= error["error"] %>
+                </li>
+              <% end %>
+            </ul>
+          </details>
+        <% end %>
+      </div>
+    </div>
+  </div>
+<% elsif status[:status] == "failed" %>
+  <div class="bg-red-50 border border-red-200 rounded-lg p-4">
+    <div class="flex items-center gap-3">
+      <svg class="h-5 w-5 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+      </svg>
+      <div>
+        <span class="font-medium text-red-900">Wikimedia image fetch failed</span>
+        <span class="text-red-700 ml-2"><%= status[:message] %></span>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/admin/ai/index.html.erb
+++ b/app/views/admin/ai/index.html.erb
@@ -563,6 +563,110 @@
     </div>
   </div>
 
+  <!-- Fetch Wikimedia Images Card -->
+  <div class="bg-white shadow rounded-lg p-6">
+    <div class="max-w-2xl mx-auto">
+      <h2 class="text-lg font-semibold text-gray-900 mb-2 text-center">Fetch Wikimedia Images</h2>
+
+      <p class="text-gray-600 mb-4 text-center text-sm">
+        Search and fetch images from Wikimedia Commons for locations that don't have photos.
+      </p>
+
+      <!-- Locations without photos count -->
+      <div class="mb-4 p-3 bg-cyan-50 rounded-lg">
+        <div class="flex items-center justify-center gap-2 text-sm">
+          <svg class="h-5 w-5 text-cyan-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
+          </svg>
+          <span class="font-semibold text-cyan-800"><%= @locations_without_photos_count %></span>
+          <span class="text-cyan-700">locations without photos</span>
+        </div>
+      </div>
+
+      <!-- Wikimedia Fetch Status -->
+      <div class="mb-4">
+        <%= render partial: "wikimedia_images_status", locals: { status: @wikimedia_fetch_status } %>
+      </div>
+
+      <ul class="text-left text-gray-600 mb-6 space-y-2 max-w-md mx-auto text-sm">
+        <li class="flex items-start gap-2">
+          <svg class="h-5 w-5 text-cyan-500 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
+          </svg>
+          <span>Searches Wikimedia Commons by location name and city</span>
+        </li>
+        <li class="flex items-start gap-2">
+          <svg class="h-5 w-5 text-cyan-500 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"></path>
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"></path>
+          </svg>
+          <span>Also searches by GPS coordinates for nearby images</span>
+        </li>
+        <li class="flex items-start gap-2">
+          <svg class="h-5 w-5 text-cyan-500 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
+          </svg>
+          <span>Downloads and attaches high-quality images (min 400x300px)</span>
+        </li>
+      </ul>
+
+      <%= form_with url: admin_fetch_wikimedia_images_admin_ai_path, method: :post, class: "space-y-4", data: { controller: "credential-form", "credential-form-username-id-value": "ai_admin_username", "credential-form-password-id-value": "ai_admin_password" } do |f| %>
+        <%= f.hidden_field :admin_username, data: { "credential-form-target": "usernameField" } %>
+        <%= f.hidden_field :admin_password, data: { "credential-form-target": "passwordField" } %>
+        <div class="flex flex-col items-center gap-4">
+          <div class="flex flex-wrap items-center justify-center gap-4">
+            <div class="flex items-center gap-2">
+              <label for="wikimedia_max_locations" class="text-sm text-gray-600">Max locations:</label>
+              <select name="max_locations" id="wikimedia_max_locations" class="rounded-md border-gray-300 shadow-sm focus:border-cyan-500 focus:ring-cyan-500 text-sm">
+                <option value="1">1</option>
+                <option value="5">5</option>
+                <option value="10" selected>10</option>
+                <option value="20">20</option>
+                <option value="50">50</option>
+              </select>
+            </div>
+
+            <div class="flex items-center gap-2">
+              <label for="wikimedia_images_per_location" class="text-sm text-gray-600">Images per location:</label>
+              <select name="images_per_location" id="wikimedia_images_per_location" class="rounded-md border-gray-300 shadow-sm focus:border-cyan-500 focus:ring-cyan-500 text-sm">
+                <option value="1">1</option>
+                <option value="3">3</option>
+                <option value="5" selected>5</option>
+                <option value="10">10</option>
+              </select>
+            </div>
+          </div>
+
+          <div class="flex flex-wrap items-center justify-center gap-4">
+            <label class="flex items-center gap-2 text-sm text-gray-600 cursor-pointer">
+              <input type="checkbox" name="use_coordinates" value="1" checked class="rounded border-gray-300 text-cyan-600 focus:ring-cyan-500">
+              <span>Also search by coordinates</span>
+            </label>
+
+            <label class="flex items-center gap-2 text-sm text-gray-600 cursor-pointer">
+              <input type="checkbox" name="dry_run" value="1" class="rounded border-gray-300 text-gray-600 focus:ring-gray-500">
+              <span>Preview only (don't attach images)</span>
+            </label>
+          </div>
+
+          <button type="submit"
+                  class="inline-flex items-center gap-2 px-6 py-3 bg-cyan-600 text-white font-medium rounded-lg hover:bg-cyan-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                  <%= "disabled" if @wikimedia_fetch_status[:status] == "in_progress" || @locations_without_photos_count.zero? %>
+                  data-action="credential-form#copyCredentials">
+            <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
+            </svg>
+            Fetch Wikimedia Images
+          </button>
+        </div>
+      <% end %>
+
+      <p class="text-xs text-gray-400 mt-4 text-center">
+        Rate-limited: 1 request/second to Wikimedia API. Images are from Wikimedia Commons (various licenses).
+      </p>
+    </div>
+  </div>
+
   <!-- Current State Stats -->
   <div class="bg-white shadow rounded-lg overflow-hidden">
     <h2 class="text-lg font-semibold p-4 sm:p-6 border-b text-gray-900">Current Content State</h2>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -156,6 +156,11 @@ Rails.application.routes.draw do
     get "ai/regenerate_translations_status", to: "ai#regenerate_translations_status", as: :regenerate_translations_status_admin_ai
     post "ai/force_reset_regenerate_translations", to: "ai#force_reset_regenerate_translations", as: :force_reset_regenerate_translations_admin_ai
 
+    # Wikimedia Image Fetch (fetch images from Wikimedia Commons for locations without photos)
+    post "ai/fetch_wikimedia_images", to: "ai#fetch_wikimedia_images", as: :fetch_wikimedia_images_admin_ai
+    get "ai/fetch_wikimedia_images_status", to: "ai#fetch_wikimedia_images_status", as: :fetch_wikimedia_images_status_admin_ai
+    post "ai/force_reset_wikimedia_fetch", to: "ai#force_reset_wikimedia_fetch", as: :force_reset_wikimedia_fetch_admin_ai
+
     # Audio Tours Generator (odvojeno od glavnog AI generatora)
     get "ai/audio_tours", to: "ai/audio_tours#index", as: :ai_audio_tours
     post "ai/audio_tours/generate", to: "ai/audio_tours#generate", as: :generate_admin_ai_audio_tours


### PR DESCRIPTION
Implement WikimediaImageFetchJob that:
- Selects random locations without attached photos
- Searches Wikimedia Commons API by location name/city
- Also searches by GPS coordinates for nearby images
- Downloads and attaches high-quality images (min 400x300px)
- Supports dry_run/preview mode to see results before attaching
- Shows image thumbnails in preview with license info

Features:
- WikimediaService for Wikimedia Commons API integration
- Rate limiting (1 req/sec) to respect API guidelines
- Admin Dashboard card with configuration options
- Status tracking with detailed results and image previews
- Force reset capability for stuck jobs