### PR TITLE
Add option to replace photos in image jobs

### DIFF
--- a/app/controllers/admin/ai_controller.rb
+++ b/app/controllers/admin/ai_controller.rb
@@ -356,17 +356,21 @@ module Admin
       max_locations = params[:max_locations].presence&.to_i || 10
       images_per_location = params[:images_per_location].presence&.to_i || 5
       use_coordinates = params[:use_coordinates] != "0"
+      replace_photos = params[:replace_photos] == "1"
 
       WikimediaImageFetchJob.clear_status!
       WikimediaImageFetchJob.perform_later(
         dry_run: dry_run,
         max_locations: max_locations,
         images_per_location: images_per_location,
-        use_coordinates: use_coordinates
+        use_coordinates: use_coordinates,
+        replace_photos: replace_photos
       )
 
       notice_msg = if dry_run
         t("admin.ai.wikimedia_fetch_preview_started", default: "Wikimedia image fetch preview started (no images will be attached)")
+      elsif replace_photos
+        t("admin.ai.wikimedia_fetch_replace_started", default: "Wikimedia image fetch started (replacing existing photos)")
       else
         t("admin.ai.wikimedia_fetch_started", default: "Wikimedia image fetch started")
       end
@@ -405,17 +409,21 @@ module Admin
       max_locations = params[:max_locations].presence&.to_i || 10
       images_per_location = params[:images_per_location].presence&.to_i || 3
       creative_commons_only = params[:creative_commons_only] == "1"
+      replace_photos = params[:replace_photos] == "1"
 
       LocationImageFinderJob.clear_status!
       LocationImageFinderJob.perform_later(
         dry_run: dry_run,
         max_locations: max_locations,
         images_per_location: images_per_location,
-        creative_commons_only: creative_commons_only
+        creative_commons_only: creative_commons_only,
+        replace_photos: replace_photos
       )
 
       notice_msg = if dry_run
         t("admin.ai.google_image_fetch_preview_started", default: "Google image search preview started (no images will be attached)")
+      elsif replace_photos
+        t("admin.ai.google_image_fetch_replace_started", default: "Google image search started (replacing existing photos)")
       else
         t("admin.ai.google_image_fetch_started", default: "Google image search started")
       end

--- a/app/views/admin/ai/index.html.erb
+++ b/app/views/admin/ai/index.html.erb
@@ -569,7 +569,7 @@
       <h2 class="text-lg font-semibold text-gray-900 mb-2 text-center">Fetch Wikimedia Images</h2>
 
       <p class="text-gray-600 mb-4 text-center text-sm">
-        Search and fetch images from Wikimedia Commons for locations that don't have photos.
+        Search and fetch images from Wikimedia Commons for locations. Can add photos to locations without any or replace existing photos.
       </p>
 
       <!-- Locations without photos count -->
@@ -647,11 +647,16 @@
               <input type="checkbox" name="dry_run" value="1" class="rounded border-gray-300 text-gray-600 focus:ring-gray-500">
               <span>Preview only (don't attach images)</span>
             </label>
+
+            <label class="flex items-center gap-2 text-sm text-gray-600 cursor-pointer">
+              <input type="checkbox" name="replace_photos" value="1" class="rounded border-gray-300 text-red-600 focus:ring-red-500">
+              <span class="text-red-600">Replace existing photos</span>
+            </label>
           </div>
 
           <button type="submit"
                   class="inline-flex items-center gap-2 px-6 py-3 bg-cyan-600 text-white font-medium rounded-lg hover:bg-cyan-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                  <%= "disabled" if @wikimedia_fetch_status[:status] == "in_progress" || @locations_without_photos_count.zero? %>
+                  <%= "disabled" if @wikimedia_fetch_status[:status] == "in_progress" %>
                   data-action="credential-form#copyCredentials">
             <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
@@ -673,7 +678,7 @@
       <h2 class="text-lg font-semibold text-gray-900 mb-2 text-center">Fetch Google Images</h2>
 
       <p class="text-gray-600 mb-4 text-center text-sm">
-        Search and fetch images using Google Custom Search API for locations that don't have photos.
+        Search and fetch images using Google Custom Search API. Can add photos to locations without any or replace existing photos.
       </p>
 
       <!-- Locations without photos count -->
@@ -751,11 +756,16 @@
               <input type="checkbox" name="dry_run" value="1" class="rounded border-gray-300 text-gray-600 focus:ring-gray-500">
               <span>Preview only (don't attach images)</span>
             </label>
+
+            <label class="flex items-center gap-2 text-sm text-gray-600 cursor-pointer">
+              <input type="checkbox" name="replace_photos" value="1" class="rounded border-gray-300 text-red-600 focus:ring-red-500">
+              <span class="text-red-600">Replace existing photos</span>
+            </label>
           </div>
 
           <button type="submit"
                   class="inline-flex items-center gap-2 px-6 py-3 bg-emerald-600 text-white font-medium rounded-lg hover:bg-emerald-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-emerald-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                  <%= "disabled" if @google_image_fetch_status[:status] == "in_progress" || @locations_without_photos_count.zero? %>
+                  <%= "disabled" if @google_image_fetch_status[:status] == "in_progress" %>
                   data-action="credential-form#copyCredentials">
             <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>


### PR DESCRIPTION
- Add replace_photos parameter to LocationImageFinderJob and WikimediaImageFetchJob
- When enabled, fetches locations WITH photos instead of without, removes existing photos before attaching new ones
- Update admin controller to pass replace_photos parameter from UI
- Add "Replace existing photos" checkbox to both Wikimedia and Google image fetching forms in admin UI