### PR TITLE
Fix SQL syntax error in image search query

### DIFF
--- a/app/jobs/location_image_finder_job.rb
+++ b/app/jobs/location_image_finder_job.rb
@@ -82,7 +82,9 @@ class LocationImageFinderJob < ApplicationJob
       locations = build_prioritized_locations_query(base_locations).limit(max_locations)
 
       # Process each location
-      locations.find_each.with_index do |location, index|
+      # Note: Using each instead of find_each because find_each doesn't work well with
+      # grouped queries (it calls .count internally which fails with aggregate selects)
+      locations.each.with_index do |location, index|
         break if index >= max_locations
 
         process_location(


### PR DESCRIPTION
Changed find_each.with_index to each.with_index because find_each internally calls .count when creating an Enumerator (for determining size), which fails on queries with aggregate SELECT clauses like COUNT(location_categories.id). The grouped query causes PostgreSQL to generate invalid SQL: COUNT(locations.*, COUNT(...)).

Using each instead is appropriate here since the query is already limited to a small number of locations (default 10).