### PR TITLE
Fix page preview rendering and missing images

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -130,6 +130,51 @@ module ApplicationHelper
     }.to_json
   end
 
+  # Open Graph meta tags helper for social media previews
+  # @param title [String] The page title
+  # @param description [String] The page description (will be truncated to 200 chars)
+  # @param image_url [String, nil] The URL for the preview image
+  # @param type [String] The OG type (default: "website")
+  # @param url [String, nil] The canonical URL (defaults to current request URL)
+  # @return [String] HTML meta tags for Open Graph and Twitter Cards
+  def og_meta_tags(title:, description:, image_url: nil, type: "website", url: nil)
+    # Sanitize and truncate description
+    clean_description = strip_tags(description.to_s).squish.truncate(200)
+    page_url = url || request.original_url
+    site_name = "Usput.ba"
+
+    # Default image if none provided
+    default_image_url = "#{request.protocol}#{request.host_with_port}/pwa-icon-512.png"
+    final_image_url = image_url.presence || default_image_url
+
+    tags = []
+
+    # Open Graph tags
+    tags << tag.meta(property: "og:title", content: title)
+    tags << tag.meta(property: "og:description", content: clean_description)
+    tags << tag.meta(property: "og:type", content: type)
+    tags << tag.meta(property: "og:url", content: page_url)
+    tags << tag.meta(property: "og:site_name", content: site_name)
+    tags << tag.meta(property: "og:image", content: final_image_url)
+    tags << tag.meta(property: "og:locale", content: I18n.locale == :bs ? "bs_BA" : "en_US")
+
+    # Twitter Card tags
+    tags << tag.meta(name: "twitter:card", content: "summary_large_image")
+    tags << tag.meta(name: "twitter:title", content: title)
+    tags << tag.meta(name: "twitter:description", content: clean_description)
+    tags << tag.meta(name: "twitter:image", content: final_image_url)
+
+    safe_join(tags, "\n")
+  end
+
+  # Default OG meta tags for pages without specific content
+  def default_og_meta_tags
+    og_meta_tags(
+      title: "Usput.ba - Experience Bosnia & Herzegovina",
+      description: t('app.description', default: 'Discover hidden gems, authentic experiences and unforgettable places in Bosnia and Herzegovina')
+    )
+  end
+
   # Returns a random hero background image path from the hero_backgrounds folder
   # If no images are found, returns nil
   def random_hero_background

--- a/app/views/experiences/show.html.erb
+++ b/app/views/experiences/show.html.erb
@@ -1,3 +1,15 @@
+<%# Open Graph meta tags for social sharing %>
+<% content_for :title do %><%= @experience.translate(:title, I18n.locale) %> - Usput.ba<% end %>
+<% content_for :meta_description do %><%= strip_tags(@experience.translate(:description, I18n.locale).to_s).squish.truncate(160) %><% end %>
+<% content_for :og_meta do %>
+  <%= og_meta_tags(
+    title: "#{@experience.translate(:title, I18n.locale)} - Usput.ba",
+    description: @experience.translate(:description, I18n.locale),
+    image_url: @experience.cover_photo.attached? ? safe_attachment_url(@experience.cover_photo, variant_options: { resize_to_fill: [1200, 630] }) : nil,
+    type: "article"
+  ) %>
+<% end %>
+
 <div class="min-h-screen bg-gray-50 dark:bg-gray-900 transition-colors duration-300 overflow-x-hidden"
      data-controller="travel-profile"
      data-travel-profile-item-id-value="<%= @experience.uuid %>"

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,7 +3,11 @@
   <head>
     <title><%= content_for(:title) || "Usput.ba - Experience Bosnia & Herzegovina" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
-    <meta name="description" content="<%= t('app.description', default: 'Discover hidden gems, authentic experiences and unforgettable places in Bosnia and Herzegovina') %>">
+    <meta name="description" content="<%= content_for(:meta_description) || t('app.description', default: 'Discover hidden gems, authentic experiences and unforgettable places in Bosnia and Herzegovina') %>">
+
+    <%# Open Graph and Twitter Card meta tags for social sharing %>
+    <%= content_for?(:og_meta) ? yield(:og_meta) : default_og_meta_tags %>
+
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <meta name="apple-mobile-web-app-title" content="Usput.ba">

--- a/app/views/locations/show.html.erb
+++ b/app/views/locations/show.html.erb
@@ -1,3 +1,15 @@
+<%# Open Graph meta tags for social sharing %>
+<% content_for :title do %><%= @location.translate(:name, I18n.locale) %> - Usput.ba<% end %>
+<% content_for :meta_description do %><%= strip_tags(@location.translate(:description, I18n.locale).to_s).squish.truncate(160) %><% end %>
+<% content_for :og_meta do %>
+  <%= og_meta_tags(
+    title: "#{@location.translate(:name, I18n.locale)} - Usput.ba",
+    description: @location.translate(:description, I18n.locale),
+    image_url: @location.photos.attached? ? safe_attachment_url(@location.photos.first, variant_options: { resize_to_fill: [1200, 630] }) : nil,
+    type: "place"
+  ) %>
+<% end %>
+
 <div class="min-h-screen bg-gray-50 dark:bg-gray-900 transition-colors duration-300 overflow-x-hidden"
      data-controller="travel-profile"
      data-travel-profile-item-id-value="<%= @location.uuid %>"

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -1,3 +1,21 @@
+<%# Open Graph meta tags for social sharing %>
+<% content_for :title do %><%= @plan.display_title %> - Usput.ba<% end %>
+<%
+  plan_description = "#{@plan.city_name} - #{@plan.duration_in_days} #{t('wizard.dates.days')}"
+  plan_description += ". #{@plan.experiences.count} #{t('nav.experiences').downcase}" if @plan.experiences.any?
+  first_experience_with_photo = @plan.experiences.find { |e| e.cover_photo.attached? }
+  plan_image_url = first_experience_with_photo ? safe_attachment_url(first_experience_with_photo.cover_photo, variant_options: { resize_to_fill: [1200, 630] }) : nil
+%>
+<% content_for :meta_description do %><%= plan_description.truncate(160) %><% end %>
+<% content_for :og_meta do %>
+  <%= og_meta_tags(
+    title: "#{@plan.display_title} - Usput.ba",
+    description: plan_description,
+    image_url: plan_image_url,
+    type: "article"
+  ) %>
+<% end %>
+
 <div class="min-h-screen bg-gray-50 dark:bg-gray-900 transition-colors duration-300 overflow-x-hidden"
      data-controller="travel-profile"
      data-travel-profile-item-id-value="<%= @plan.uuid %>"


### PR DESCRIPTION
- Add og_meta_tags helper to ApplicationHelper for generating OG meta tags
- Update application layout to include OG/Twitter meta tags
- Add page-specific OG meta tags to locations, experiences, and plans show pages
- Include proper title, description, and image for each content type
- Use default logo image when no specific image is available

This fixes the issue where shared links showed "browser not supported" instead of proper page previews with logo and images.