### PR TITLE
Identify and restore medical facilities

### DIFF
--- a/app/controllers/admin/ai_controller.rb
+++ b/app/controllers/admin/ai_controller.rb
@@ -125,12 +125,22 @@ module Admin
       dry_run = params[:dry_run] == "1"
       clear_cache = params[:clear_cache] == "1"
 
+      # Removal options (unchecked = don't remove, checked = remove)
+      remove_outside_bih = params[:remove_outside_bih] == "1"
+      remove_medical_facilities = params[:remove_medical_facilities] == "1"
+      remove_soup_kitchens = params[:remove_soup_kitchens] == "1"
+      remove_city_mismatches = params[:remove_city_mismatches] == "1"
+
       LocationCityFixJob.clear_status!
       LocationCityFixJob.perform_later(
         regenerate_content: regenerate_content,
         analyze_descriptions: analyze_descriptions,
         dry_run: dry_run,
-        clear_cache: clear_cache
+        clear_cache: clear_cache,
+        remove_outside_bih: remove_outside_bih,
+        remove_medical_facilities: remove_medical_facilities,
+        remove_soup_kitchens: remove_soup_kitchens,
+        remove_city_mismatches: remove_city_mismatches
       )
 
       notice_msg = if dry_run

--- a/app/views/admin/ai/index.html.erb
+++ b/app/views/admin/ai/index.html.erb
@@ -209,6 +209,31 @@
             </label>
           </div>
 
+          <!-- Removal options -->
+          <div class="flex flex-wrap items-center justify-center gap-4 pt-2 border-t border-gray-200">
+            <span class="text-xs text-gray-500 w-full text-center">Remove locations that are:</span>
+
+            <label class="flex items-center gap-2 text-sm text-gray-600 cursor-pointer">
+              <input type="checkbox" name="remove_outside_bih" value="1" checked class="rounded border-gray-300 text-red-600 focus:ring-red-500">
+              <span class="text-red-600">Outside BiH</span>
+            </label>
+
+            <label class="flex items-center gap-2 text-sm text-gray-600 cursor-pointer">
+              <input type="checkbox" name="remove_medical_facilities" value="1" checked class="rounded border-gray-300 text-red-600 focus:ring-red-500">
+              <span class="text-red-600">Medical facilities</span>
+            </label>
+
+            <label class="flex items-center gap-2 text-sm text-gray-600 cursor-pointer">
+              <input type="checkbox" name="remove_soup_kitchens" value="1" checked class="rounded border-gray-300 text-red-600 focus:ring-red-500">
+              <span class="text-red-600">Soup kitchens</span>
+            </label>
+
+            <label class="flex items-center gap-2 text-sm text-gray-600 cursor-pointer">
+              <input type="checkbox" name="remove_city_mismatches" value="1" checked class="rounded border-gray-300 text-red-600 focus:ring-red-500">
+              <span class="text-red-600">City name mismatches</span>
+            </label>
+          </div>
+
           <button type="submit"
                   class="inline-flex items-center gap-2 px-6 py-3 bg-orange-600 text-white font-medium rounded-lg hover:bg-orange-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                   <%= "disabled" if @fix_cities_status[:status] == "in_progress" %>


### PR DESCRIPTION
Expose the job's removal parameters in the admin dashboard:
- Remove outside BiH
- Remove medical facilities
- Remove soup kitchens
- Remove city name mismatches

All options default to checked (matching job defaults).