### PR TITLE
Redirect to explore page on not found

### DIFF
--- a/app/controllers/experiences_controller.rb
+++ b/app/controllers/experiences_controller.rb
@@ -1,4 +1,6 @@
 class ExperiencesController < ApplicationController
+  rescue_from ActiveRecord::RecordNotFound, with: :redirect_to_explore
+
   def show
     @experience = Experience.includes(:locations, :reviews).find_by_public_id!(params[:id])
     @reviews = @experience.reviews.recent.limit(10)
@@ -12,5 +14,11 @@ class ExperiencesController < ApplicationController
                       .distinct
     @related_plans = plans_scope.order(average_rating: :desc).limit(3)
     @total_plans_count = plans_scope.count
+  end
+
+  private
+
+  def redirect_to_explore
+    redirect_to explore_path, alert: I18n.t("experiences.not_found", default: "Experience not found. Explore other experiences.")
   end
 end

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -1,4 +1,6 @@
 class LocationsController < ApplicationController
+  rescue_from ActiveRecord::RecordNotFound, with: :redirect_to_explore
+
   def show
     @location = Location.includes(:reviews).find_by_public_id!(params[:id])
     @reviews = @location.reviews.recent.limit(10)
@@ -24,5 +26,11 @@ class LocationsController < ApplicationController
 
   def audio_tour
     @location = Location.find_by_public_id!(params[:id])
+  end
+
+  private
+
+  def redirect_to_explore
+    redirect_to explore_path, alert: I18n.t("locations.not_found", default: "Location not found. Explore other destinations.")
   end
 end

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -1,4 +1,6 @@
 class PlansController < ApplicationController
+  rescue_from ActiveRecord::RecordNotFound, with: :redirect_to_explore
+
   # Plan generation constants
   DEFAULT_DAILY_HOURS = 6        # Default hours of active tourism per day
   MIN_DAILY_HOURS = 2            # Minimum allowed daily hours
@@ -490,5 +492,9 @@ class PlansController < ApplicationController
     else
       "#{mins}min"
     end
+  end
+
+  def redirect_to_explore
+    redirect_to explore_path, alert: I18n.t("plans.not_found", default: "Plan not found. Explore other plans.")
   end
 end


### PR DESCRIPTION
Instead of showing a 404 error page when a resource is not found, users are now redirected to the explore page with an informative flash message. This provides a better user experience by guiding them to discover other content.