### PR TITLE
Fix API response schema validation error

### DIFF
--- a/app/services/ai/experience_location_syncer.rb
+++ b/app/services/ai/experience_location_syncer.rb
@@ -238,7 +238,7 @@ module Ai
                 city: { type: "string" },
                 context: { type: "string" }
               },
-              required: %w[name confidence],
+              required: %w[name confidence city context],
               additionalProperties: false
             }
           }


### PR DESCRIPTION
Add 'city' and 'context' to the required array in the extraction schema. OpenAI's structured outputs API requires all properties to be listed in the 'required' array when 'additionalProperties: false' is set.