### PR TITLE
Fix missing translations column in location syncer

### DIFF
--- a/app/services/ai/experience_location_syncer.rb
+++ b/app/services/ai/experience_location_syncer.rb
@@ -290,7 +290,7 @@ module Ai
       if defined?(Translation)
         translation = Translation.where(
           translatable_type: "Location",
-          key: "name"
+          field_name: "name"
         ).where("LOWER(value) LIKE ?", "%#{normalized_name.downcase}%").first
 
         if translation


### PR DESCRIPTION
The Translation model uses 'field_name' column to store the attribute name being translated, not 'key'. This fixes the PG::UndefinedColumn error when ExperienceLocationSyncer tries to search for locations by translated name.