### PR TITLE
Fix Geoapify API category validation error

### DIFF
--- a/config/initializers/geoapify.rb
+++ b/config/initializers/geoapify.rb
@@ -84,10 +84,6 @@ Rails.application.config.geoapify.tourism_categories = %w[
   catering.fast_food.chicken
   catering.fast_food.ice_cream
   catering.bar
-  catering.bar.wine
-  catering.bar.cocktail
-  catering.bar.beer
-  catering.bar.sports
   catering.pub
   catering.biergarten
   catering.taproom
@@ -156,18 +152,16 @@ Rails.application.config.geoapify.tourism_categories = %w[
   commercial.food_and_drink.bakery
   commercial.food_and_drink.deli
   commercial.food_and_drink.butcher
-  commercial.food_and_drink.wine
-  commercial.food_and_drink.beverages
-  commercial.food_and_drink.greengrocer
+  commercial.food_and_drink.drinks
+  commercial.food_and_drink.fruit_and_vegetable
   commercial.food_and_drink.farm
   commercial.food_and_drink.honey
   commercial.food_and_drink.health_food
   commercial.food_and_drink.frozen_food
   commercial.food_and_drink.seafood
-  commercial.food_and_drink.cheese
+  commercial.food_and_drink.cheese_and_dairy
   commercial.food_and_drink.chocolate
-  commercial.food_and_drink.coffee
-  commercial.food_and_drink.tea
+  commercial.food_and_drink.coffee_and_tea
   commercial.food_and_drink.spices
   commercial.food_and_drink.confectionery
   commercial.food_and_drink.pasta


### PR DESCRIPTION
- Remove invalid categories from DEFAULT_CATEGORY_TYPE_MAPPING (e.g., catering.bar.wine, entertainment.casino, leisure.garden)
- Update DEFAULT_TOURISM_CATEGORIES to only contain valid Geoapify categories
- Add comprehensive category mapping in find_matching_category to convert invalid/deprecated categories to valid alternatives:
  - wine → production.winery
  - entertainment.casino → adult.casino
  - entertainment.night_club → adult.nightclub
  - leisure.garden → leisure.park.garden
  - leisure.sauna → leisure.spa.sauna
  - production.distillery → production.brewery
  - service.townhall → tourism.sights.city_hall
  - service.embassy → office.diplomatic
  - ski.resort → ski
  - sport.* invalid categories → valid sport alternatives
  - tourism.viewpoint → tourism.attraction.viewpoint
  - tourism.artwork → tourism.attraction.artwork
  - And many more...
- Update config/initializers/geoapify.rb with valid category names
- This ensures backward compatibility for requested categories while preventing API errors from invalid Geoapify categories