### PR TITLE
Fix Google image search download failures

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,7 @@ gem "ruby_llm"
 
 # HTTP client for Geoapify API
 gem "faraday"
+gem "faraday-follow_redirects"  # Follow HTTP redirects for image downloads
 
 # Pagination
 gem "kaminari"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,6 +148,8 @@ GEM
       multipart-post (~> 2.0)
     faraday-net_http (3.4.2)
       net-http (~> 0.5)
+    faraday-follow_redirects (0.5.0)
+      faraday (>= 1, < 3)
     faraday-retry (2.4.0)
       faraday (~> 2.0)
     ffi (1.17.3)
@@ -492,6 +494,7 @@ DEPENDENCIES
   debug
   dotenv-rails
   faraday
+  faraday-follow_redirects
   flipper
   flipper-active_record
   geocoder

--- a/app/jobs/location_image_finder_job.rb
+++ b/app/jobs/location_image_finder_job.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "faraday/follow_redirects"
+
 # Background job for finding and attaching images to locations using Google Custom Search API.
 #
 # Usage:


### PR DESCRIPTION
The faraday.response :follow_redirects middleware requires the faraday-follow_redirects gem which was missing. This caused all image downloads to fail because many image URLs redirect to the actual image location, and without this gem, Faraday cannot follow HTTP redirects.

- Add faraday-follow_redirects (v0.5.0) to Gemfile and Gemfile.lock
- Add require statement in LocationImageFinderJob for Faraday 2.x