### PR TITLE
Add AI tag when user publishes plan

### DIFF
--- a/app/models/content_change.rb
+++ b/app/models/content_change.rb
@@ -207,6 +207,10 @@ class ContentChange < ApplicationRecord
     # Filter to only allowed attributes - prevent mass assignment
     allowed_attrs = safe_attributes_for(klass)
     safe_data = proposed_data.slice(*allowed_attrs)
+
+    # Curator-created content is human-made, not AI-generated
+    safe_data["ai_generated"] = false if klass.column_names.include?("ai_generated")
+
     record = klass.new(safe_data)
     record.save!
     update!(changeable: record)

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -337,7 +337,8 @@ class Plan < ApplicationRecord
       local_id: data["id"],
       visibility: :private_plan,
       preferences: preferences,
-      notes: sanitized_notes
+      notes: sanitized_notes,
+      ai_generated: false  # User-created plans via wizard are human-made
     )
 
     if plan.save

--- a/app/services/ai/country_wide_location_generator.rb
+++ b/app/services/ai/country_wide_location_generator.rb
@@ -1587,7 +1587,8 @@ module Ai
         budget: :medium,
         website: geoapify_data&.dig(:website),
         phone: geoapify_data&.dig(:phone),
-        tags: build_tags(suggestion, source_region)
+        tags: build_tags(suggestion, source_region),
+        ai_generated: true  # Explicitly mark as AI-generated
       )
 
       # Generate rich content with AI (use verified city name)

--- a/app/services/ai/experience_creator.rb
+++ b/app/services/ai/experience_creator.rb
@@ -122,7 +122,8 @@ module Ai
         title: initial_title,
         estimated_duration: proposal[:estimated_duration] || calculate_duration(locations),
         experience_category: category,
-        seasons: proposal[:seasons] || []
+        seasons: proposal[:seasons] || [],
+        ai_generated: true  # Explicitly mark as AI-generated
       )
 
       if experience.save

--- a/app/services/ai/experience_generator.rb
+++ b/app/services/ai/experience_generator.rb
@@ -327,7 +327,8 @@ module Ai
         budget: place[:price_level] || :medium,
         website: place[:website],
         phone: place[:phone],
-        tags: extract_tags(place[:types])
+        tags: extract_tags(place[:types]),
+        ai_generated: true  # Explicitly mark as AI-generated
       )
 
       # Set translations (name, description, historical_context)

--- a/app/services/ai/location_enricher.rb
+++ b/app/services/ai/location_enricher.rb
@@ -97,7 +97,8 @@ module Ai
         budget: determine_budget(place_data),
         website: normalize_website_url(place_data[:website]),
         phone: sanitized_phone,
-        email: sanitized_email
+        email: sanitized_email,
+        ai_generated: true  # Explicitly mark as AI-generated
       )
 
       # Save location first so it has an ID for translations

--- a/app/services/ai/plan_creator.rb
+++ b/app/services/ai/plan_creator.rb
@@ -322,6 +322,7 @@ module Ai
         title: initial_title,
         city_name: city || determine_primary_city(proposal, experiences),
         visibility: :public_plan,
+        ai_generated: true,  # Explicitly mark as AI-generated
         preferences: {
           "tourist_profile" => profile,
           "generated_by_ai" => true,


### PR DESCRIPTION
- User-created plans via wizard: ai_generated: false
- Curator-created content (via ContentChange): ai_generated: false
- AI services (PlanCreator, ExperienceCreator, etc.): ai_generated: true

This ensures proper distinction between human-made and AI-generated content, regardless of database defaults.