### PR TITLE
Set default filter on Explore page

### DIFF
--- a/app/controllers/new_design_controller.rb
+++ b/app/controllers/new_design_controller.rb
@@ -45,7 +45,7 @@ class NewDesignController < ApplicationController
     @lat = params[:lat].presence&.to_f
     @lng = params[:lng].presence&.to_f
     @radius = params[:radius].presence&.to_i || 25
-    @sort = params[:sort].presence || "newest"
+    @sort = params[:sort].presence || "relevance"
 
     # Pagination params per resource type
     @locations_page = (params[:locations_page] || 1).to_i


### PR DESCRIPTION
Previously the Explore page defaulted to sorting by "newest". This changes the default to "relevance" which prioritizes items by rating and review count, providing a better user experience for discovering quality content.