### PR TITLE
Delete experience model images by city or ID

### DIFF
--- a/app/controllers/admin/ai_controller.rb
+++ b/app/controllers/admin/ai_controller.rb
@@ -30,6 +30,7 @@ module Admin
       @wikimedia_fetch_status = WikimediaImageFetchJob.current_status
       @google_image_fetch_status = LocationImageFinderJob.current_status
       @delete_location_photos_status = DeleteLocationPhotosJob.current_status
+      @delete_experience_photos_status = DeleteExperiencePhotosJob.current_status
       @locations_without_photos_count = count_locations_without_photos
       @cities_with_photos = cities_with_photos
       @last_generation = parse_last_generation
@@ -514,6 +515,58 @@ module Admin
     def force_reset_delete_location_photos
       DeleteLocationPhotosJob.force_reset!
       redirect_to admin_ai_path, notice: t("admin.ai.delete_location_photos_force_reset", default: "Photo deletion has been force reset. You can now start a new run.")
+    end
+
+    # POST /admin/ai/delete_experience_photos
+    # Deletes cover photos from experiences by ID or city
+    def delete_experience_photos
+      current_status = DeleteExperiencePhotosJob.current_status
+      if current_status[:status] == "in_progress"
+        redirect_to admin_ai_path, alert: t("admin.ai.delete_experience_photos_already_in_progress", default: "Experience photo deletion is already in progress")
+        return
+      end
+
+      dry_run = params[:dry_run] == "1"
+      experience_id = params[:experience_id].presence
+      city = params[:city].presence
+
+      if experience_id.blank? && city.blank?
+        redirect_to admin_ai_path, alert: t("admin.ai.delete_experience_photos_no_target", default: "Please specify an experience ID or city")
+        return
+      end
+
+      DeleteExperiencePhotosJob.clear_status!
+      DeleteExperiencePhotosJob.perform_later(
+        experience_id: experience_id,
+        city: city,
+        dry_run: dry_run
+      )
+
+      notice_msg = if dry_run
+        t("admin.ai.delete_experience_photos_preview_started", default: "Experience photo deletion preview started (no photos will be deleted)")
+      else
+        t("admin.ai.delete_experience_photos_started", default: "Experience photo deletion started")
+      end
+
+      redirect_to admin_ai_path, notice: notice_msg
+    end
+
+    # GET /admin/ai/delete_experience_photos_status (AJAX)
+    # Returns current status of experience photo deletion job
+    def delete_experience_photos_status
+      @delete_status = DeleteExperiencePhotosJob.current_status
+
+      respond_to do |format|
+        format.json { render json: @delete_status }
+        format.html { render partial: "delete_experience_photos_status", locals: { status: @delete_status } }
+      end
+    end
+
+    # POST /admin/ai/force_reset_delete_experience_photos
+    # Force resets a stuck or in-progress experience photo deletion job
+    def force_reset_delete_experience_photos
+      DeleteExperiencePhotosJob.force_reset!
+      redirect_to admin_ai_path, notice: t("admin.ai.delete_experience_photos_force_reset", default: "Experience photo deletion has been force reset. You can now start a new run.")
     end
 
     private

--- a/app/jobs/delete_experience_photos_job.rb
+++ b/app/jobs/delete_experience_photos_job.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+# Background job for deleting cover photos from experiences by ID or city.
+#
+# Usage:
+#   DeleteExperiencePhotosJob.perform_later(experience_id: "uuid")           # Delete cover photo for single experience
+#   DeleteExperiencePhotosJob.perform_later(experience_ids: ["uuid1", "uuid2"])  # Delete cover photos for multiple experiences
+#   DeleteExperiencePhotosJob.perform_later(city: "Sarajevo")                # Delete cover photos for all experiences in city
+#   DeleteExperiencePhotosJob.perform_later(experience_id: "uuid", dry_run: true)  # Preview without deleting
+#
+class DeleteExperiencePhotosJob < ApplicationJob
+  queue_as :default
+
+  def perform(experience_id: nil, experience_ids: nil, city: nil, dry_run: false)
+    Rails.logger.info "[DeleteExperiencePhotosJob] Starting (experience_id: #{experience_id}, experience_ids: #{experience_ids&.size}, city: #{city}, dry_run: #{dry_run})"
+
+    save_status("in_progress", "Starting cover photo deletion...")
+
+    results = {
+      started_at: Time.current,
+      dry_run: dry_run,
+      experience_id: experience_id,
+      experience_ids: experience_ids,
+      city: city,
+      experiences_processed: 0,
+      photos_deleted: 0,
+      errors: [],
+      experience_results: []
+    }
+
+    begin
+      experiences = find_experiences(experience_id: experience_id, experience_ids: experience_ids, city: city)
+
+      if experiences.empty?
+        results[:status] = "completed"
+        results[:message] = "No experiences found to process"
+        results[:finished_at] = Time.current
+        save_status("completed", results[:message], results: results)
+        return results
+      end
+
+      results[:total_experiences] = experiences.size
+      save_status("in_progress", "Found #{experiences.size} experiences to process")
+
+      experiences.find_each.with_index do |experience, index|
+        save_status("in_progress", "Processing #{index + 1}/#{results[:total_experiences]}: #{experience.title}")
+        process_experience(experience, results, dry_run: dry_run)
+      end
+
+      results[:status] = "completed"
+      results[:message] = build_completion_summary(results)
+      results[:finished_at] = Time.current
+
+      save_status("completed", results[:message], results: results)
+      results
+    rescue StandardError => e
+      results[:status] = "failed"
+      results[:message] = "Error: #{e.message}"
+      results[:finished_at] = Time.current
+      save_status("failed", results[:message], results: results)
+      raise
+    end
+  end
+
+  # Returns current status of the job
+  def self.current_status
+    {
+      status: Setting.get("delete_experience_photos.status", default: "idle"),
+      message: Setting.get("delete_experience_photos.message", default: nil),
+      results: JSON.parse(Setting.get("delete_experience_photos.results", default: "{}") || "{}")
+    }
+  rescue JSON::ParserError
+    { status: "idle", message: nil, results: {} }
+  end
+
+  # Clear any existing status
+  def self.clear_status!
+    Setting.set("delete_experience_photos.status", "idle")
+    Setting.set("delete_experience_photos.message", nil)
+    Setting.set("delete_experience_photos.results", "{}")
+  end
+
+  # Force reset a stuck job
+  def self.force_reset!
+    Setting.set("delete_experience_photos.status", "idle")
+    Setting.set("delete_experience_photos.message", "Force reset by admin")
+  end
+
+  private
+
+  def find_experiences(experience_id:, experience_ids:, city:)
+    if experience_id.present?
+      Experience.where(id: experience_id)
+    elsif experience_ids.present?
+      Experience.where(id: experience_ids)
+    elsif city.present?
+      # Find experiences that have at least one location in the specified city
+      Experience.joins(:locations).where(locations: { city: city }).distinct
+    else
+      Experience.none
+    end
+  end
+
+  def process_experience(experience, results, dry_run:)
+    has_cover_photo = experience.cover_photo.attached?
+
+    unless has_cover_photo
+      Rails.logger.info "[DeleteExperiencePhotosJob] Experience #{experience.id} (#{experience.title}) has no cover photo, skipping"
+      return
+    end
+
+    Rails.logger.info "[DeleteExperiencePhotosJob] #{dry_run ? '[DRY RUN] Would delete' : 'Deleting'} cover photo from experience #{experience.id} (#{experience.title})"
+
+    experience_result = {
+      id: experience.id,
+      title: experience.title,
+      city: experience.city,
+      photos_count: 1
+    }
+
+    unless dry_run
+      begin
+        experience.cover_photo.purge
+        experience_result[:status] = "deleted"
+      rescue StandardError => e
+        Rails.logger.error "[DeleteExperiencePhotosJob] Error deleting cover photo for experience #{experience.id}: #{e.message}"
+        experience_result[:status] = "error"
+        experience_result[:error] = e.message
+        results[:errors] << { experience_id: experience.id, error: e.message }
+      end
+    else
+      experience_result[:status] = "would_delete"
+    end
+
+    results[:experiences_processed] += 1
+    results[:photos_deleted] += 1 unless dry_run || experience_result[:status] == "error"
+    results[:experience_results] << experience_result
+  end
+
+  def build_completion_summary(results)
+    parts = []
+
+    if results[:dry_run]
+      parts << "Preview completed:"
+    else
+      parts << "Completed:"
+    end
+
+    parts << "#{results[:experiences_processed]} experiences processed"
+    parts << "#{results[:photos_deleted]} cover photos deleted"
+
+    if results[:errors].any?
+      parts << "#{results[:errors].count} errors"
+    end
+
+    parts.join(", ")
+  end
+
+  def save_status(status, message, results: nil)
+    Setting.set("delete_experience_photos.status", status)
+    Setting.set("delete_experience_photos.message", message)
+    Setting.set("delete_experience_photos.results", results.to_json) if results
+  rescue StandardError => e
+    Rails.logger.warn "[DeleteExperiencePhotosJob] Could not save status: #{e.message}"
+  end
+end

--- a/app/views/admin/ai/_delete_experience_photos_status.html.erb
+++ b/app/views/admin/ai/_delete_experience_photos_status.html.erb
@@ -1,0 +1,95 @@
+<% if status[:status] == "in_progress" %>
+  <div class="bg-blue-50 border border-blue-200 rounded-lg p-4">
+    <div class="flex items-center justify-between gap-3">
+      <div class="flex items-center gap-3">
+        <svg class="animate-spin h-5 w-5 text-blue-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+          <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+        </svg>
+        <div>
+          <span class="font-medium text-blue-900">Experience photo deletion in progress</span>
+          <span class="text-blue-700 ml-2"><%= status[:message] %></span>
+        </div>
+      </div>
+      <%= form_with url: admin_force_reset_delete_experience_photos_admin_ai_path, method: :post, class: "inline", data: { turbo_confirm: "Are you sure? This will reset the deletion status and allow you to start a new run.", controller: "credential-form", "credential-form-username-id-value": "ai_admin_username", "credential-form-password-id-value": "ai_admin_password" } do |f| %>
+        <%= f.hidden_field :admin_username, data: { "credential-form-target": "usernameField" } %>
+        <%= f.hidden_field :admin_password, data: { "credential-form-target": "passwordField" } %>
+        <button type="submit"
+                class="inline-flex items-center gap-1 px-3 py-1.5 bg-red-600 text-white text-sm font-medium rounded hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 transition-colors"
+                data-action="credential-form#copyCredentials">
+          Force Stop & Restart
+        </button>
+      <% end %>
+    </div>
+  </div>
+<% elsif status[:status] == "completed" && status[:results].present? %>
+  <div class="bg-green-50 border border-green-200 rounded-lg p-4">
+    <div class="flex items-start gap-3">
+      <svg class="h-5 w-5 text-green-600 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
+      </svg>
+      <div class="flex-1">
+        <span class="font-medium text-green-900">
+          <%= status[:results]["dry_run"] ? "Preview completed" : "Experience photo deletion completed" %>
+        </span>
+        <p class="text-green-700 text-sm mt-1"><%= status[:message] %></p>
+
+        <% if status[:results]["experience_results"].present? && status[:results]["experience_results"].any? %>
+          <details class="mt-3">
+            <summary class="text-sm text-green-700 cursor-pointer hover:underline font-medium">
+              View <%= status[:results]["experience_results"].size %> experience results
+              (<%= status[:results]["photos_deleted"] %> cover photos <%= status[:results]["dry_run"] ? "would be deleted" : "deleted" %>)
+            </summary>
+            <div class="mt-3 space-y-2 max-h-64 overflow-y-auto">
+              <% status[:results]["experience_results"].each do |exp_result| %>
+                <div class="bg-white rounded-lg p-3 border border-green-100 flex items-center justify-between">
+                  <div>
+                    <span class="font-medium text-gray-900"><%= exp_result["title"] %></span>
+                    <span class="text-xs text-gray-500 ml-2">(<%= exp_result["city"] %>)</span>
+                  </div>
+                  <span class="text-sm <%= exp_result["status"] == "deleted" || exp_result["status"] == "would_delete" ? 'text-red-600' : 'text-gray-600' %>">
+                    <%= exp_result["photos_count"] %> cover photo
+                    <% if exp_result["status"] == "deleted" %>
+                      deleted
+                    <% elsif exp_result["status"] == "would_delete" %>
+                      (would delete)
+                    <% elsif exp_result["status"] == "error" %>
+                      <span class="text-red-600">error</span>
+                    <% end %>
+                  </span>
+                </div>
+              <% end %>
+            </div>
+          </details>
+        <% end %>
+
+        <% if status[:results]["errors"].present? && status[:results]["errors"].any? %>
+          <details class="mt-2">
+            <summary class="text-sm text-red-600 cursor-pointer hover:underline">
+              View <%= status[:results]["errors"].size %> errors
+            </summary>
+            <ul class="mt-2 text-xs text-red-700 space-y-1 max-h-40 overflow-y-auto">
+              <% status[:results]["errors"].each do |error| %>
+                <li class="bg-red-50 rounded px-2 py-1">
+                  <strong>Experience <%= error["experience_id"] %></strong>: <%= error["error"] %>
+                </li>
+              <% end %>
+            </ul>
+          </details>
+        <% end %>
+      </div>
+    </div>
+  </div>
+<% elsif status[:status] == "failed" %>
+  <div class="bg-red-50 border border-red-200 rounded-lg p-4">
+    <div class="flex items-center gap-3">
+      <svg class="h-5 w-5 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+      </svg>
+      <div>
+        <span class="font-medium text-red-900">Experience photo deletion failed</span>
+        <span class="text-red-700 ml-2"><%= status[:message] %></span>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/admin/ai/index.html.erb
+++ b/app/views/admin/ai/index.html.erb
@@ -907,6 +907,93 @@
     </div>
   </div>
 
+  <!-- Delete Experience Photos Card -->
+  <div class="bg-white shadow rounded-lg p-6">
+    <div class="max-w-2xl mx-auto">
+      <h2 class="text-lg font-semibold text-gray-900 mb-2 text-center">Delete Experience Photos</h2>
+
+      <p class="text-gray-600 mb-4 text-center text-sm">
+        Delete cover photos from a specific experience by ID or from all experiences in a city.
+      </p>
+
+      <!-- Delete Status -->
+      <div class="mb-4">
+        <%= render partial: "delete_experience_photos_status", locals: { status: @delete_experience_photos_status } %>
+      </div>
+
+      <ul class="text-left text-gray-600 mb-6 space-y-2 max-w-md mx-auto text-sm">
+        <li class="flex items-start gap-2">
+          <svg class="h-5 w-5 text-red-500 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
+          </svg>
+          <span>Delete cover photos by experience ID or by city</span>
+        </li>
+        <li class="flex items-start gap-2">
+          <svg class="h-5 w-5 text-red-500 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"></path>
+          </svg>
+          <span>Use preview mode first to see what will be deleted</span>
+        </li>
+        <li class="flex items-start gap-2">
+          <svg class="h-5 w-5 text-red-500 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"></path>
+          </svg>
+          <span>Useful for cleaning up bad images before re-generating</span>
+        </li>
+      </ul>
+
+      <%= form_with url: admin_delete_experience_photos_admin_ai_path, method: :post, class: "space-y-4", data: { controller: "credential-form", "credential-form-username-id-value": "ai_admin_username", "credential-form-password-id-value": "ai_admin_password" } do |f| %>
+        <%= f.hidden_field :admin_username, data: { "credential-form-target": "usernameField" } %>
+        <%= f.hidden_field :admin_password, data: { "credential-form-target": "passwordField" } %>
+        <div class="flex flex-col items-center gap-4">
+          <div class="flex flex-wrap items-center justify-center gap-4">
+            <div class="flex items-center gap-2">
+              <label for="delete_experience_id" class="text-sm text-gray-600">Experience ID:</label>
+              <input type="text"
+                     name="experience_id"
+                     id="delete_experience_id"
+                     placeholder="UUID"
+                     class="w-64 rounded-md border-gray-300 shadow-sm focus:border-red-500 focus:ring-red-500 text-sm font-mono">
+            </div>
+
+            <span class="text-sm text-gray-400">or</span>
+
+            <div class="flex items-center gap-2">
+              <label for="delete_experience_city" class="text-sm text-gray-600">City:</label>
+              <select name="city" id="delete_experience_city" class="rounded-md border-gray-300 shadow-sm focus:border-red-500 focus:ring-red-500 text-sm">
+                <option value="">Select city...</option>
+                <% @cities_with_photos.each do |city| %>
+                  <option value="<%= city %>"><%= city %></option>
+                <% end %>
+              </select>
+            </div>
+          </div>
+
+          <div class="flex flex-wrap items-center justify-center gap-4">
+            <label class="flex items-center gap-2 text-sm text-gray-600 cursor-pointer">
+              <input type="checkbox" name="dry_run" value="1" checked class="rounded border-gray-300 text-gray-600 focus:ring-gray-500">
+              <span>Preview only (no photos will be deleted)</span>
+            </label>
+          </div>
+
+          <button type="submit"
+                  class="inline-flex items-center gap-2 px-6 py-3 bg-red-600 text-white font-medium rounded-lg hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                  <%= "disabled" if @delete_experience_photos_status[:status] == "in_progress" %>
+                  data-action="credential-form#copyCredentials">
+            <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
+            </svg>
+            Delete Experience Photos
+          </button>
+        </div>
+      <% end %>
+
+      <p class="text-xs text-gray-400 mt-4 text-center">
+        Warning: This action permanently deletes cover photos. Always use preview mode first!
+      </p>
+    </div>
+  </div>
+
   <!-- Current State Stats -->
   <div class="bg-white shadow rounded-lg overflow-hidden">
     <h2 class="text-lg font-semibold p-4 sm:p-6 border-b text-gray-900">Current Content State</h2>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -171,6 +171,11 @@ Rails.application.routes.draw do
     get "ai/delete_location_photos_status", to: "ai#delete_location_photos_status", as: :delete_location_photos_status_admin_ai
     post "ai/force_reset_delete_location_photos", to: "ai#force_reset_delete_location_photos", as: :force_reset_delete_location_photos_admin_ai
 
+    # Delete Experience Photos (delete cover photos from experiences by ID or city)
+    post "ai/delete_experience_photos", to: "ai#delete_experience_photos", as: :delete_experience_photos_admin_ai
+    get "ai/delete_experience_photos_status", to: "ai#delete_experience_photos_status", as: :delete_experience_photos_status_admin_ai
+    post "ai/force_reset_delete_experience_photos", to: "ai#force_reset_delete_experience_photos", as: :force_reset_delete_experience_photos_admin_ai
+
     # Audio Tours Generator (odvojeno od glavnog AI generatora)
     get "ai/audio_tours", to: "ai/audio_tours#index", as: :ai_audio_tours
     post "ai/audio_tours/generate", to: "ai/audio_tours#generate", as: :generate_admin_ai_audio_tours


### PR DESCRIPTION
Add DeleteExperiencePhotosJob that allows deleting cover photos from experiences by UUID or by city. This is similar to the existing DeleteLocationPhotosJob but adapted for Experience model which has a single cover_photo attachment instead of multiple photos.

Features:
- Delete by experience UUID or by city (via location relationships)
- Dry-run/preview mode to see what would be deleted
- Status tracking with real-time progress updates
- Admin dashboard UI with form and status display
- Force reset functionality for stuck jobs