### PR TITLE
Remove all photos from experiences and locations

### DIFF
--- a/db/migrate/20260111192507_remove_all_photos_from_experiences_and_locations.rb
+++ b/db/migrate/20260111192507_remove_all_photos_from_experiences_and_locations.rb
@@ -1,0 +1,18 @@
+class RemoveAllPhotosFromExperiencesAndLocations < ActiveRecord::Migration[8.1]
+  def up
+    # Remove all cover photos from experiences
+    Experience.find_each do |experience|
+      experience.cover_photo.purge if experience.cover_photo.attached?
+    end
+
+    # Remove all photos from locations
+    Location.find_each do |location|
+      location.photos.purge if location.photos.attached?
+    end
+  end
+
+  def down
+    # Photos cannot be restored once deleted
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_01_09_193210) do
+ActiveRecord::Schema[8.1].define(version: 2026_01_11_192507) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 


### PR DESCRIPTION
Purge all Active Storage photos from Experience (cover_photo) and Location (photos) models to clean up storage.