### PR TITLE
Fix Docker build by excluding test and ci gem groups

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update -qq && \
 ENV RAILS_ENV="production" \
     BUNDLE_DEPLOYMENT="1" \
     BUNDLE_PATH="/usr/local/bundle" \
-    BUNDLE_WITHOUT="development" \
+    BUNDLE_WITHOUT="development:test:ci" \
     LD_PRELOAD="/usr/local/lib/libjemalloc.so"
 
 # Throw-away build stage to reduce size of final image


### PR DESCRIPTION
## Summary
- Fix production Docker build failure caused by `undercover` gem requiring CMake
- Change `BUNDLE_WITHOUT` from `development` to `development:test:ci`
- The `undercover` gem (in `:ci` group) depends on `rugged`, which requires CMake and libgit2 to build native extensions

## Test plan
- [ ] Verify Docker build succeeds on deploy
- [ ] Confirm production app starts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)