### PR TITLE
Fix platform database setup in Docker

### DIFF
--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -2,9 +2,12 @@
 
 # If running the rails server then prepare all databases
 if [ "${@: -2:1}" == "./bin/rails" ] && [ "${@: -1:1}" == "server" ]; then
-  # Prepare primary, queue, and platform databases
+  # Prepare primary and queue databases
   ./bin/rails db:prepare
-  ./bin/rails db:prepare:platform
+
+  # Prepare platform database (create if not exists, then migrate)
+  ./bin/rails db:create:platform || true
+  ./bin/rails db:migrate:platform
 fi
 
 exec "$@"


### PR DESCRIPTION
## Summary
- Fix `db:prepare:platform` which doesn't exist as a Rails task
- Use `db:create:platform` + `db:migrate:platform` instead

## Test plan
- [ ] Deploy to production

🤖 Generated with [Claude Code](https://claude.com/claude-code)