### PR TITLE
Fix coordinate validation and nil truncate errors

### DIFF
--- a/app/views/experiences/show.html.erb
+++ b/app/views/experiences/show.html.erb
@@ -503,7 +503,7 @@
              data-controller="add-to-plan"
              data-add-to-plan-experience-id-value="<%= @experience.uuid %>"
              data-add-to-plan-experience-title-value="<%= @experience.translate(:title, I18n.locale) %>"
-             data-add-to-plan-experience-description-value="<%= @experience.translate(:description, I18n.locale).truncate(150) %>"
+             data-add-to-plan-experience-description-value="<%= @experience.translate(:description, I18n.locale)&.truncate(150) || '' %>"
              data-add-to-plan-experience-duration-value="<%= @experience.formatted_duration %>">
 
             <%# When user has no plan %>

--- a/app/views/new_design/home.html.erb
+++ b/app/views/new_design/home.html.erb
@@ -527,7 +527,7 @@
                       <%= t("home.trending.location") %>
                     </h3>
                     <p class="mt-2 text-lg font-medium tracking-tight text-gray-950 dark:text-white"><%= location.translate(:name, I18n.locale) %></p>
-                    <p class="mt-2 max-w-lg text-sm/6 text-gray-600 dark:text-gray-400 line-clamp-2"><%= truncate(location.translate(:description, I18n.locale), length: 120) %></p>
+                    <p class="mt-2 max-w-lg text-sm/6 text-gray-600 dark:text-gray-400 line-clamp-2"><%= truncate(location.translate(:description, I18n.locale).to_s, length: 120) %></p>
                     <div class="mt-3 flex items-center gap-2">
                       <% if location.average_rating.to_f > 0 %>
                         <div class="flex items-center text-yellow-500">
@@ -569,7 +569,7 @@
                       <%= t("home.trending.location") %>
                     </h3>
                     <p class="mt-2 text-lg font-medium tracking-tight text-gray-950 dark:text-white"><%= location.translate(:name, I18n.locale) %></p>
-                    <p class="mt-2 max-w-lg text-sm/6 text-gray-600 dark:text-gray-400 line-clamp-2"><%= truncate(location.translate(:description, I18n.locale), length: 120) %></p>
+                    <p class="mt-2 max-w-lg text-sm/6 text-gray-600 dark:text-gray-400 line-clamp-2"><%= truncate(location.translate(:description, I18n.locale).to_s, length: 120) %></p>
                     <div class="mt-3 flex items-center gap-2">
                       <% if location.average_rating.to_f > 0 %>
                         <div class="flex items-center text-yellow-500">
@@ -611,7 +611,7 @@
                       <%= t("home.trending.location") %>
                     </h3>
                     <p class="mt-2 text-lg font-medium tracking-tight text-gray-950 dark:text-white"><%= location.translate(:name, I18n.locale) %></p>
-                    <p class="mt-2 max-w-lg text-sm/6 text-gray-600 dark:text-gray-400 line-clamp-2"><%= truncate(location.translate(:description, I18n.locale), length: 80) %></p>
+                    <p class="mt-2 max-w-lg text-sm/6 text-gray-600 dark:text-gray-400 line-clamp-2"><%= truncate(location.translate(:description, I18n.locale).to_s, length: 80) %></p>
                     <div class="mt-3 flex items-center gap-2">
                       <% if location.average_rating.to_f > 0 %>
                         <div class="flex items-center text-yellow-500">
@@ -655,7 +655,7 @@
                     <%= t("home.trending.experience") %>
                   </h3>
                   <p class="mt-2 text-lg font-medium tracking-tight text-gray-950 dark:text-white"><%= experience.translate(:title, I18n.locale) %></p>
-                  <p class="mt-2 max-w-lg text-sm/6 text-gray-600 dark:text-gray-400 line-clamp-2"><%= truncate(experience.translate(:description, I18n.locale), length: 80) %></p>
+                  <p class="mt-2 max-w-lg text-sm/6 text-gray-600 dark:text-gray-400 line-clamp-2"><%= truncate(experience.translate(:description, I18n.locale).to_s, length: 80) %></p>
                   <div class="mt-3 flex items-center gap-2">
                     <% if experience.average_rating.to_f > 0 %>
                       <div class="flex items-center text-yellow-500">

--- a/lib/platform/dsl/executors/content.rb
+++ b/lib/platform/dsl/executors/content.rb
@@ -79,6 +79,12 @@ module Platform
               end
             end
 
+            # CRITICAL: Require coordinates for locations
+            # This prevents creating locations with unknown/wrong coordinates
+            if is_location_table?(table) && !(data[:lat].present? && data[:lng].present?)
+              raise ExecutionError, "Lokacija '#{data[:name]}' ne može biti kreirana bez koordinata. Geoapify nije pronašao tačnu lokaciju. Koristi explicit lat/lng ili search_pois za pronalazak POI-ja sa koordinatama."
+            end
+
             # For locations, check for existing by coordinates first (find-or-create pattern)
             if is_location_table?(table) && data[:lat] && data[:lng]
               existing = Location.find_by_coordinates_fuzzy(data[:lat], data[:lng])
@@ -255,6 +261,23 @@ module Platform
 
               # Use Geoapify coordinates if not explicitly provided
               unless data[:lat].present? && data[:lng].present?
+                # CRITICAL: Validate that the result is actually in the expected city
+                # Geoapify text_search often returns wrong locations when POI doesn't exist
+                if city.present? && best_match[:address].present?
+                  address_lower = best_match[:address].to_s.downcase
+                  city_lower = city.downcase
+
+                  # Check if the address contains the city name (with some flexibility for diacritics)
+                  city_normalized = city_lower.gsub(/[čćžšđ]/, 'c' => 'c', 'ć' => 'c', 'ž' => 'z', 'š' => 's', 'đ' => 'd')
+                  address_normalized = address_lower.gsub(/[čćžšđ]/, 'c' => 'c', 'ć' => 'c', 'ž' => 'z', 'š' => 's', 'đ' => 'd')
+
+                  unless address_normalized.include?(city_normalized) || address_lower.include?(city_lower)
+                    Rails.logger.warn "[DSL::Content] Geoapify result for '#{name}' is not in expected city '#{city}'. Address: #{best_match[:address]}. Skipping coordinates."
+                    # Don't use coordinates from wrong city - return data without lat/lng enrichment
+                    return data
+                  end
+                end
+
                 enriched[:lat] = best_match[:lat]
                 enriched[:lng] = best_match[:lng]
               end

--- a/test/lib/platform/dsl/executors/content_test.rb
+++ b/test/lib/platform/dsl/executors/content_test.rb
@@ -746,7 +746,8 @@ class Platform::DSL::Executors::ContentTest < ActiveSupport::TestCase
 
     Location.stub(:new, ->(_data) { mock_location }) do
       error = assert_raises(Platform::DSL::ExecutionError) do
-        Platform::DSL::Executors::Content.send(:execute_create, "locations", { name: "Test", city: "Sarajevo" })
+        # Include lat/lng to pass coordinate validation
+        Platform::DSL::Executors::Content.send(:execute_create, "locations", { name: "Test", city: "Sarajevo", lat: 43.85, lng: 18.38 })
       end
       assert_match(/Kreiranje nije uspjelo/, error.message)
     end
@@ -810,8 +811,8 @@ class Platform::DSL::Executors::ContentTest < ActiveSupport::TestCase
     assert_in_delta 43.9, @location.lat, 0.01
   end
 
-  test "execute_create for location without coordinates" do
-    # Test creating location without lat/lng (BiH check is skipped)
+  test "execute_create for location without coordinates raises error" do
+    # Creating location without lat/lng is now disallowed
     ast = {
       type: :mutation,
       action: :create,
@@ -822,8 +823,10 @@ class Platform::DSL::Executors::ContentTest < ActiveSupport::TestCase
       }
     }
 
-    result = Platform::DSL::Executors::Content.execute_mutation(ast)
-    assert result[:success]
+    error = assert_raises(Platform::DSL::ExecutionError) do
+      Platform::DSL::Executors::Content.execute_mutation(ast)
+    end
+    assert_match(/ne može biti kreirana bez koordinata/, error.message)
   end
 
   test "format_created_record handles location with nil description" do

--- a/test/lib/platform/dsl/mutations_test.rb
+++ b/test/lib/platform/dsl/mutations_test.rb
@@ -61,7 +61,7 @@ class Platform::DSL::MutationsTest < ActiveSupport::TestCase
 
   test "creates audit log on create" do
     assert_difference "PlatformAuditLog.count", 1 do
-      Platform::DSL.execute('create location { name: "Audit Test", city: "Tuzla" }')
+      Platform::DSL.execute('create location { name: "Audit Test", city: "Tuzla", lat: 44.54, lng: 18.67 }')
     end
 
     log = PlatformAuditLog.last


### PR DESCRIPTION
## Summary
- Add city validation in Geoapify enrichment to prevent locations getting wrong coordinates (e.g. "Stari most Goražde" showing Mostar coordinates)
- Require explicit coordinates for location creation via DSL - prevents creating locations with unknown/incorrect positions
- Fix truncate on nil errors in experience show and home page views

## Test plan
- [x] All tests pass (3794 runs, 0 failures)
- [ ] Verify home page loads without errors when locations have nil descriptions
- [ ] Verify experience show page loads without errors when experience has nil description
- [ ] Test DSL location creation requires coordinates

🤖 Generated with [Claude Code](https://claude.com/claude-code)